### PR TITLE
Visual polish: side-by-side diff, severity bar, toast notification

### DIFF
--- a/client/src/components/app-shell.ts
+++ b/client/src/components/app-shell.ts
@@ -47,6 +47,15 @@ export class AppShell extends LitElement {
       context: Record<string, unknown>;
     };
 
+    // Client-only actions that don't need a server round-trip
+    if (detail.name === 'toggle_finding' || detail.name === 'modal_cancel') {
+      if (detail.name === 'toggle_finding') {
+        this.updateSelectedCount(detail.surfaceId);
+      }
+      this.renderKey++;
+      return;
+    }
+
     if (!this.client || !this.contextId || !this.taskId) return;
 
     const action: UserAction = {
@@ -74,6 +83,28 @@ export class AppShell extends LitElement {
       this.statusHistory = [];
     }
   };
+
+  private updateSelectedCount(surfaceId: string): void {
+    const surface = this.surfaceManager.getSurface(surfaceId);
+    if (!surface) return;
+
+    // Count selected findings across all file groups in findings_all
+    let count = 0;
+    const findingsAll = surface.data.findings_all;
+    if (findingsAll && typeof findingsAll === 'object') {
+      for (const fileGroup of Object.values(findingsAll as Record<string, Record<string, unknown>>)) {
+        const findings = fileGroup.findings;
+        if (findings && typeof findings === 'object') {
+          for (const finding of Object.values(findings as Record<string, Record<string, unknown>>)) {
+            if (finding.selected) count++;
+          }
+        }
+      }
+    }
+
+    surface.data.post_selected_label = `Post Selected (${count})`;
+    surface.data.modal_message = `${count} finding${count !== 1 ? 's' : ''} will be posted as inline comments on the PR.`;
+  }
 
   private async handleSubmit(): Promise<void> {
     const input = this.inputValue.trim();

--- a/client/src/components/app-shell.ts
+++ b/client/src/components/app-shell.ts
@@ -58,6 +58,14 @@ export class AppShell extends LitElement {
 
     if (!this.client || !this.contextId || !this.taskId) return;
 
+    // Compute selected findings at dispatch time (data model string may be stale)
+    if (detail.name === 'post_selected') {
+      const surface = this.surfaceManager.getSurface(detail.surfaceId);
+      if (surface) {
+        detail.context.selectedFindings = JSON.stringify(this.collectSelectedFindings(surface));
+      }
+    }
+
     const action: UserAction = {
       name: detail.name,
       surfaceId: detail.surfaceId,
@@ -104,6 +112,27 @@ export class AppShell extends LitElement {
 
     surface.data.post_selected_label = `Post Selected (${count})`;
     surface.data.modal_message = `${count} finding${count !== 1 ? 's' : ''} will be posted as inline comments on the PR.`;
+  }
+
+  private collectSelectedFindings(surface: Surface): Array<Record<string, unknown>> {
+    const findings: Array<Record<string, unknown>> = [];
+    const findingsAll = surface.data.findings_all;
+    if (!findingsAll || typeof findingsAll !== 'object') return findings;
+    for (const fileGroup of Object.values(findingsAll as Record<string, Record<string, unknown>>)) {
+      const fileFindings = fileGroup.findings;
+      if (!fileFindings || typeof fileFindings !== 'object') continue;
+      for (const finding of Object.values(fileFindings as Record<string, Record<string, unknown>>)) {
+        if (finding.selected) {
+          findings.push({
+            id: finding.id,
+            severity_icon: finding.severity_icon,
+            file_path: finding.file_path,
+            description: finding.description,
+          });
+        }
+      }
+    }
+    return findings;
   }
 
   private async handleSubmit(): Promise<void> {

--- a/client/src/components/app-shell.ts
+++ b/client/src/components/app-shell.ts
@@ -33,6 +33,7 @@ export class AppShell extends LitElement {
   private taskId: string | undefined;
   private inputValue = '';
   private toastTimer: ReturnType<typeof setTimeout> | null = null;
+  private toastDismissTimer: ReturnType<typeof setTimeout> | null = null;
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -235,6 +236,7 @@ export class AppShell extends LitElement {
 
   private showToast(message: string, link: string): void {
     if (this.toastTimer) clearTimeout(this.toastTimer);
+    if (this.toastDismissTimer) clearTimeout(this.toastDismissTimer);
     this.toastMessage = message;
     this.toastLink = link;
     this.toastVisible = true;
@@ -247,11 +249,13 @@ export class AppShell extends LitElement {
       clearTimeout(this.toastTimer);
       this.toastTimer = null;
     }
+    if (this.toastDismissTimer) clearTimeout(this.toastDismissTimer);
     this.toastDismissing = true;
-    setTimeout(() => {
+    this.toastDismissTimer = setTimeout(() => {
       this.toastVisible = false;
       this.toastDismissing = false;
-    }, 200); // match slideOutRight duration
+      this.toastDismissTimer = null;
+    }, 200);
   }
 
   private async handleChat(): Promise<void> {

--- a/client/src/components/app-shell.ts
+++ b/client/src/components/app-shell.ts
@@ -22,12 +22,17 @@ export class AppShell extends LitElement {
   @state() private renderKey = 0;
 
   @state() private chatInput = '';
+  @state() private toastMessage = '';
+  @state() private toastLink = '';
+  @state() private toastVisible = false;
+  @state() private toastDismissing = false;
 
   private client: A2AClient | null = null;
   private surfaceManager = new SurfaceManager();
   private contextId: string | undefined;
   private taskId: string | undefined;
   private inputValue = '';
+  private toastTimer: ReturnType<typeof setTimeout> | null = null;
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -197,10 +202,56 @@ export class AppShell extends LitElement {
     }
 
     if (collectedA2UI.length > 0) {
+      // Snapshot the review surface before processing so we can restore it if this is a post result
+      const reviewSurface = this.surfaceManager.getSurface('review');
+      const snapshot = reviewSurface ? {
+        components: new Map(reviewSurface.components),
+        data: { ...reviewSurface.data },
+        root: reviewSurface.root,
+      } : null;
+
       this.surfaceManager.processBatch(collectedA2UI);
+
+      // Detect post result: the review surface root changed to "result-col"
+      const updatedReview = this.surfaceManager.getSurface('review');
+      if (updatedReview && updatedReview.root === 'result-col' && snapshot) {
+        // Extract toast data before restoring
+        const message = String(updatedReview.data.result_message ?? 'Review posted');
+        const link = String(updatedReview.data.result_link ?? '');
+
+        // Restore the dashboard
+        updatedReview.components = snapshot.components;
+        updatedReview.data = snapshot.data;
+        updatedReview.root = snapshot.root;
+
+        // Show toast
+        this.showToast(message, link);
+      }
+
       this.activeSurfaces = this.surfaceManager.getReadySurfaces();
       this.renderKey++;
     }
+  }
+
+  private showToast(message: string, link: string): void {
+    if (this.toastTimer) clearTimeout(this.toastTimer);
+    this.toastMessage = message;
+    this.toastLink = link;
+    this.toastVisible = true;
+    this.toastDismissing = false;
+    this.toastTimer = setTimeout(() => this.dismissToast(), 4000);
+  }
+
+  private dismissToast(): void {
+    if (this.toastTimer) {
+      clearTimeout(this.toastTimer);
+      this.toastTimer = null;
+    }
+    this.toastDismissing = true;
+    setTimeout(() => {
+      this.toastVisible = false;
+      this.toastDismissing = false;
+    }, 200); // match slideOutRight duration
   }
 
   private async handleChat(): Promise<void> {
@@ -289,11 +340,24 @@ export class AppShell extends LitElement {
         : nothing}
 
       ${this.activeSurfaces.map(
-        (surface) => html`
-          <div class="surface-container" key=${`${surface.surfaceId}-${this.renderKey}`}>
-            ${renderComponent(surface.root, surface)}
-          </div>
-        `,
+        (surface) => {
+          const critical = parseInt(String(surface.data.critical_count ?? ''), 10) || 0;
+          const warning = parseInt(String(surface.data.warning_count ?? ''), 10) || 0;
+          const info = parseInt(String(surface.data.info_count ?? ''), 10) || 0;
+          const total = critical + warning + info;
+          return html`
+            <div class="surface-container" key=${`${surface.surfaceId}-${this.renderKey}`}>
+              ${total > 0 ? html`
+                <div class="severity-bar">
+                  <div class="severity-bar__segment severity-bar__segment--critical" style="width:${(critical / total) * 100}%"></div>
+                  <div class="severity-bar__segment severity-bar__segment--warning" style="width:${(warning / total) * 100}%"></div>
+                  <div class="severity-bar__segment severity-bar__segment--info" style="width:${(info / total) * 100}%"></div>
+                </div>
+              ` : nothing}
+              ${renderComponent(surface.root, surface)}
+            </div>
+          `;
+        },
       )}
 
       ${this.activeSurfaces.length > 0
@@ -309,6 +373,23 @@ export class AppShell extends LitElement {
               />
               <button @click=${this.handleChat} ?disabled=${this.loading || !this.chatInput.trim()}>
                 Send
+              </button>
+            </div>
+          `
+        : nothing}
+
+      ${this.toastVisible
+        ? html`
+            <div class="toast${this.toastDismissing ? ' toast--dismissing' : ''}">
+              <div class="toast__icon"><span class="material-icons">check_circle</span></div>
+              <div class="toast__content">
+                <div class="toast__message">${this.toastMessage}</div>
+                ${this.toastLink
+                  ? html`<a class="toast__link" href=${this.toastLink} target="_blank" rel="noopener noreferrer">View on GitHub</a>`
+                  : nothing}
+              </div>
+              <button class="toast__close" @click=${() => this.dismissToast()}>
+                <span class="material-icons">close</span>
               </button>
             </div>
           `

--- a/client/src/components/app-shell.ts
+++ b/client/src/components/app-shell.ts
@@ -48,7 +48,7 @@ export class AppShell extends LitElement {
     };
 
     // Client-only actions that don't need a server round-trip
-    if (detail.name === 'toggle_finding' || detail.name === 'modal_cancel') {
+    if (detail.name === 'toggle_finding' || detail.name === 'modal_cancel' || detail.name === 'tab_switch') {
       if (detail.name === 'toggle_finding') {
         this.updateSelectedCount(detail.surfaceId);
       }

--- a/client/src/renderer.ts
+++ b/client/src/renderer.ts
@@ -304,18 +304,18 @@ function renderTabs(
   const tabItems = props.tabItems as Array<{title: BoundValue; child: string}> | undefined;
   if (!tabItems || tabItems.length === 0) return html`<div class="a2ui-tabs"></div>`;
 
+  // Store active tab in surface data so it survives re-renders
+  const tabKey = '__active_tab';
+  const activeTab = Number(surface.data[tabKey] ?? 0);
+
   const handleTabClick = (e: Event, index: number) => {
-    // Walk up from the clicked button to find the .a2ui-tabs container
-    let container = (e.target as HTMLElement).closest('.a2ui-tabs');
-    if (!container) return;
-    const headers = container.querySelectorAll('.a2ui-tabs__tab');
-    const panels = container.querySelectorAll('.a2ui-tabs__panel');
-    headers.forEach((h, i) => {
-      h.classList.toggle('a2ui-tabs__tab--active', i === index);
+    surface.data[tabKey] = index;
+    const event = new CustomEvent('a2ui-action', {
+      bubbles: true,
+      composed: true,
+      detail: { name: 'tab_switch', surfaceId: surface.surfaceId },
     });
-    panels.forEach((p, i) => {
-      p.classList.toggle('a2ui-tabs__panel--hidden', i !== index);
-    });
+    (e.currentTarget as HTMLElement).dispatchEvent(event);
   };
 
   return html`
@@ -325,14 +325,14 @@ function renderTabs(
           const title = item.title ? String(resolveValue(item.title, surface.data, scope) ?? '') : '';
           return html`
             <button
-              class="a2ui-tabs__tab${i === 0 ? ' a2ui-tabs__tab--active' : ''}"
+              class="a2ui-tabs__tab${i === activeTab ? ' a2ui-tabs__tab--active' : ''}"
               @click=${(e: Event) => handleTabClick(e, i)}
             >${title}</button>
           `;
         })}
       </div>
       ${tabItems.map((item, i) => html`
-        <div class="a2ui-tabs__panel${i !== 0 ? ' a2ui-tabs__panel--hidden' : ''}">
+        <div class="a2ui-tabs__panel${i !== activeTab ? ' a2ui-tabs__panel--hidden' : ''}">
           ${item.child ? renderComponent(item.child, surface, scope) : nothing}
         </div>
       `)}

--- a/client/src/renderer.ts
+++ b/client/src/renderer.ts
@@ -359,12 +359,14 @@ function renderModal(
     }
   };
 
-  // Listen for modal_cancel action to close the modal
+  // Close modal on any action from within (cancel or confirm)
   const handleAction = (e: Event) => {
     const detail = (e as CustomEvent).detail;
-    if (detail?.name === 'modal_cancel') {
-      const overlay = findOverlay(e.target as HTMLElement);
-      if (overlay) overlay.style.display = 'none';
+    if (!detail?.name) return;
+    const overlay = findOverlay(e.target as HTMLElement);
+    if (overlay) overlay.style.display = 'none';
+    // Cancel is client-only, don't propagate to server
+    if (detail.name === 'modal_cancel') {
       e.stopPropagation();
     }
   };

--- a/client/src/renderer.ts
+++ b/client/src/renderer.ts
@@ -65,6 +65,15 @@ export function renderComponent(
     case 'Image':
       content = renderImage(props, surface.data, scope);
       break;
+    case 'Tabs':
+      content = renderTabs(props, surface, scope);
+      break;
+    case 'Modal':
+      content = renderModal(props, surface, scope);
+      break;
+    case 'CheckBox':
+      content = renderCheckBox(props, surface, id, scope);
+      break;
     default:
       content = html`<div class="a2ui-unknown">[Unknown: ${type}]</div>`;
   }
@@ -280,6 +289,153 @@ function renderImage(
   const fit = (props.fit as string) || 'contain';
   const url = urlBinding ? String(resolveValue(urlBinding, data, scope) ?? '') : '';
   return html`<img class="a2ui-image" src=${url} style="object-fit:${fit}" />`;
+}
+
+function renderTabs(
+  props: Record<string, unknown>,
+  surface: Surface,
+  scope?: string,
+): TemplateResult {
+  const tabItems = props.tabItems as Array<{title: BoundValue; child: string}> | undefined;
+  if (!tabItems || tabItems.length === 0) return html`<div class="a2ui-tabs"></div>`;
+
+  const tabId = `tabs-${Math.random().toString(36).slice(2, 8)}`;
+
+  const handleTabClick = (index: number) => {
+    const container = document.querySelector(`[data-tab-id="${tabId}"]`);
+    if (!container) return;
+    const headers = container.querySelectorAll('.a2ui-tabs__tab');
+    const panels = container.querySelectorAll('.a2ui-tabs__panel');
+    headers.forEach((h, i) => {
+      h.classList.toggle('a2ui-tabs__tab--active', i === index);
+    });
+    panels.forEach((p, i) => {
+      p.classList.toggle('a2ui-tabs__panel--hidden', i !== index);
+    });
+  };
+
+  return html`
+    <div class="a2ui-tabs" data-tab-id=${tabId}>
+      <div class="a2ui-tabs__header">
+        ${tabItems.map((item, i) => {
+          const title = item.title ? String(resolveValue(item.title, surface.data, scope) ?? '') : '';
+          return html`
+            <button
+              class="a2ui-tabs__tab${i === 0 ? ' a2ui-tabs__tab--active' : ''}"
+              @click=${() => handleTabClick(i)}
+            >${title}</button>
+          `;
+        })}
+      </div>
+      ${tabItems.map((item, i) => html`
+        <div class="a2ui-tabs__panel${i !== 0 ? ' a2ui-tabs__panel--hidden' : ''}">
+          ${item.child ? renderComponent(item.child, surface, scope) : nothing}
+        </div>
+      `)}
+    </div>
+  `;
+}
+
+function renderModal(
+  props: Record<string, unknown>,
+  surface: Surface,
+  scope?: string,
+): TemplateResult {
+  const entryPointId = props.entryPointChild as string;
+  const contentId = props.contentChild as string;
+
+  const modalId = `modal-${Math.random().toString(36).slice(2, 8)}`;
+
+  const openModal = () => {
+    const overlay = document.querySelector(`[data-modal-id="${modalId}"]`);
+    if (overlay) (overlay as HTMLElement).style.display = 'flex';
+  };
+
+  const closeModal = () => {
+    const overlay = document.querySelector(`[data-modal-id="${modalId}"]`);
+    if (overlay) (overlay as HTMLElement).style.display = 'none';
+  };
+
+  const handleBackdropClick = (e: Event) => {
+    if (e.target === e.currentTarget) closeModal();
+  };
+
+  // Listen for modal_cancel action to close the modal
+  const handleAction = (e: Event) => {
+    const detail = (e as CustomEvent).detail;
+    if (detail?.name === 'modal_cancel') {
+      closeModal();
+      e.stopPropagation();
+    }
+  };
+
+  return html`
+    <div class="a2ui-modal" @a2ui-action=${handleAction}>
+      <div @click=${openModal}>
+        ${entryPointId ? renderComponent(entryPointId, surface, scope) : nothing}
+      </div>
+      <div class="a2ui-modal-overlay" data-modal-id=${modalId} style="display:none" @click=${handleBackdropClick}>
+        <div class="a2ui-modal-content">
+          ${contentId ? renderComponent(contentId, surface, scope) : nothing}
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+function renderCheckBox(
+  props: Record<string, unknown>,
+  surface: Surface,
+  componentId: string,
+  scope?: string,
+): TemplateResult {
+  const labelBinding = props.label as BoundValue | undefined;
+  const valueBinding = props.value as BoundValue | undefined;
+  const label = labelBinding ? String(resolveValue(labelBinding, surface.data, scope) ?? '') : '';
+  const checked = valueBinding ? Boolean(resolveValue(valueBinding, surface.data, scope)) : false;
+
+  const handleChange = (e: Event) => {
+    const newChecked = (e.target as HTMLInputElement).checked;
+
+    // Update local data model if value has a path binding
+    if (valueBinding && 'path' in valueBinding) {
+      const p = valueBinding.path;
+      const fullPath = p.startsWith('/') ? p : (scope ? `${scope}/${p}` : p);
+      const segments = fullPath.replace(/^\//, '').split('/').filter(Boolean);
+      let current: Record<string, unknown> = surface.data;
+      for (let i = 0; i < segments.length - 1; i++) {
+        const seg = segments[i];
+        if (current[seg] == null || typeof current[seg] !== 'object') {
+          current[seg] = {};
+        }
+        current = current[seg] as Record<string, unknown>;
+      }
+      current[segments[segments.length - 1]] = newChecked;
+    }
+
+    // Dispatch action to server
+    const event = new CustomEvent('a2ui-action', {
+      bubbles: true,
+      composed: true,
+      detail: {
+        name: 'toggle_finding',
+        sourceComponentId: componentId,
+        surfaceId: surface.surfaceId,
+        context: {
+          findingId: resolveValue({path: 'id'} as BoundValue, surface.data, scope),
+          selected: newChecked,
+        },
+      },
+    });
+    document.dispatchEvent(event);
+  };
+
+  return html`
+    <label class="a2ui-checkbox">
+      <input type="checkbox" .checked=${checked} @change=${handleChange} />
+      ${label ? html`<span class="a2ui-checkbox__label">${label}</span>` : nothing}
+    </label>
+  `;
 }
 
 function renderChildren(

--- a/client/src/renderer.ts
+++ b/client/src/renderer.ts
@@ -99,21 +99,64 @@ function isDiffContent(text: string): boolean {
   return diffLineCount >= 2;
 }
 
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 function renderDiffBlock(text: string): TemplateResult {
   // Handle both real newlines and escaped \n
   const lines = text.includes('\n') ? text.split('\n') : text.split('\\n');
-  const lineHtml = lines
-    .map((line) => {
-      const trimmed = line.trimStart();
-      let cls = 'a2ui-diff-line a2ui-diff-line--ctx';
-      if (trimmed.startsWith('+')) cls = 'a2ui-diff-line a2ui-diff-line--add';
-      else if (trimmed.startsWith('-')) cls = 'a2ui-diff-line a2ui-diff-line--del';
-      // Escape HTML entities
-      const escaped = line.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-      return `<div class="${cls}">${escaped}</div>`;
-    })
-    .join('');
-  return html`<pre class="a2ui-diff">${unsafeHTML(lineHtml)}</pre>`;
+
+  // Group consecutive - and + lines into paired rows
+  type DiffRow = { type: 'ctx'; text: string } | { type: 'pair'; del: string[]; add: string[] };
+  const rows: DiffRow[] = [];
+  let pendingDel: string[] = [];
+  let pendingAdd: string[] = [];
+
+  const flushPending = () => {
+    if (pendingDel.length > 0 || pendingAdd.length > 0) {
+      rows.push({ type: 'pair', del: pendingDel, add: pendingAdd });
+      pendingDel = [];
+      pendingAdd = [];
+    }
+  };
+
+  for (const line of lines) {
+    const trimmed = line.trimStart();
+    if (trimmed.startsWith('-')) {
+      // If we had pending adds without dels following, flush first
+      if (pendingAdd.length > 0 && pendingDel.length === 0) flushPending();
+      pendingDel.push(trimmed.slice(1));
+    } else if (trimmed.startsWith('+')) {
+      pendingAdd.push(trimmed.slice(1));
+    } else {
+      flushPending();
+      if (trimmed.length > 0) {
+        rows.push({ type: 'ctx', text: line });
+      }
+    }
+  }
+  flushPending();
+
+  const rowsHtml = rows.map((row) => {
+    if (row.type === 'ctx') {
+      return `<div class="a2ui-diff-row"><div class="a2ui-diff-col a2ui-diff-col--ctx">${escapeHtml(row.text)}</div></div>`;
+    }
+    const maxLen = Math.max(row.del.length, row.add.length);
+    let pairHtml = '';
+    for (let i = 0; i < maxLen; i++) {
+      const delLine = i < row.del.length
+        ? `<div class="a2ui-diff-col a2ui-diff-col--del">${escapeHtml(row.del[i])}</div>`
+        : '<div class="a2ui-diff-col a2ui-diff-col--empty"></div>';
+      const addLine = i < row.add.length
+        ? `<div class="a2ui-diff-col a2ui-diff-col--add">${escapeHtml(row.add[i])}</div>`
+        : '<div class="a2ui-diff-col a2ui-diff-col--empty"></div>';
+      pairHtml += `<div class="a2ui-diff-row">${delLine}${addLine}</div>`;
+    }
+    return pairHtml;
+  }).join('');
+
+  return html`<pre class="a2ui-diff a2ui-diff--split">${unsafeHTML(rowsHtml)}</pre>`;
 }
 
 function renderText(

--- a/client/src/renderer.ts
+++ b/client/src/renderer.ts
@@ -129,6 +129,11 @@ function renderText(
     return renderDiffBlock(text);
   }
 
+  if (text.startsWith('https://') || text.startsWith('http://')) {
+    const label = text.includes('github.com') ? 'View on GitHub' : text;
+    return html`<a class="a2ui-text a2ui-text--${usageHint} a2ui-text--link" href=${text} target="_blank" rel="noopener noreferrer">${label}</a>`;
+  }
+
   return html`<div class="a2ui-text a2ui-text--${usageHint}">${text}</div>`;
 }
 
@@ -227,7 +232,7 @@ function renderButton(
   const action = props.action as Action | undefined;
   const className = primary ? 'a2ui-button a2ui-button--primary' : 'a2ui-button';
 
-  const handleClick = () => {
+  const handleClick = (e: Event) => {
     if (!action) return;
     const resolvedContext: Record<string, unknown> = {};
     if (action.context) {
@@ -235,7 +240,7 @@ function renderButton(
         resolvedContext[item.key] = resolveValue(item.value, surface.data, scope);
       }
     }
-    const event = new CustomEvent('a2ui-action', {
+    const customEvent = new CustomEvent('a2ui-action', {
       bubbles: true,
       composed: true,
       detail: {
@@ -245,7 +250,7 @@ function renderButton(
         context: resolvedContext,
       },
     });
-    document.dispatchEvent(event);
+    (e.currentTarget as HTMLElement).dispatchEvent(customEvent);
   };
 
   return html`

--- a/client/src/renderer.ts
+++ b/client/src/renderer.ts
@@ -299,10 +299,9 @@ function renderTabs(
   const tabItems = props.tabItems as Array<{title: BoundValue; child: string}> | undefined;
   if (!tabItems || tabItems.length === 0) return html`<div class="a2ui-tabs"></div>`;
 
-  const tabId = `tabs-${Math.random().toString(36).slice(2, 8)}`;
-
-  const handleTabClick = (index: number) => {
-    const container = document.querySelector(`[data-tab-id="${tabId}"]`);
+  const handleTabClick = (e: Event, index: number) => {
+    // Walk up from the clicked button to find the .a2ui-tabs container
+    let container = (e.target as HTMLElement).closest('.a2ui-tabs');
     if (!container) return;
     const headers = container.querySelectorAll('.a2ui-tabs__tab');
     const panels = container.querySelectorAll('.a2ui-tabs__panel');
@@ -315,14 +314,14 @@ function renderTabs(
   };
 
   return html`
-    <div class="a2ui-tabs" data-tab-id=${tabId}>
+    <div class="a2ui-tabs">
       <div class="a2ui-tabs__header">
         ${tabItems.map((item, i) => {
           const title = item.title ? String(resolveValue(item.title, surface.data, scope) ?? '') : '';
           return html`
             <button
               class="a2ui-tabs__tab${i === 0 ? ' a2ui-tabs__tab--active' : ''}"
-              @click=${() => handleTabClick(i)}
+              @click=${(e: Event) => handleTabClick(e, i)}
             >${title}</button>
           `;
         })}
@@ -344,27 +343,28 @@ function renderModal(
   const entryPointId = props.entryPointChild as string;
   const contentId = props.contentChild as string;
 
-  const modalId = `modal-${Math.random().toString(36).slice(2, 8)}`;
-
-  const openModal = () => {
-    const overlay = document.querySelector(`[data-modal-id="${modalId}"]`);
-    if (overlay) (overlay as HTMLElement).style.display = 'flex';
+  const findOverlay = (el: HTMLElement): HTMLElement | null => {
+    const modal = el.closest('.a2ui-modal');
+    return modal ? modal.querySelector('.a2ui-modal-overlay') : null;
   };
 
-  const closeModal = () => {
-    const overlay = document.querySelector(`[data-modal-id="${modalId}"]`);
-    if (overlay) (overlay as HTMLElement).style.display = 'none';
+  const openModal = (e: Event) => {
+    const overlay = findOverlay(e.target as HTMLElement);
+    if (overlay) overlay.style.display = 'flex';
   };
 
   const handleBackdropClick = (e: Event) => {
-    if (e.target === e.currentTarget) closeModal();
+    if (e.target === e.currentTarget) {
+      (e.currentTarget as HTMLElement).style.display = 'none';
+    }
   };
 
   // Listen for modal_cancel action to close the modal
   const handleAction = (e: Event) => {
     const detail = (e as CustomEvent).detail;
     if (detail?.name === 'modal_cancel') {
-      closeModal();
+      const overlay = findOverlay(e.target as HTMLElement);
+      if (overlay) overlay.style.display = 'none';
       e.stopPropagation();
     }
   };
@@ -374,7 +374,7 @@ function renderModal(
       <div @click=${openModal}>
         ${entryPointId ? renderComponent(entryPointId, surface, scope) : nothing}
       </div>
-      <div class="a2ui-modal-overlay" data-modal-id=${modalId} style="display:none" @click=${handleBackdropClick}>
+      <div class="a2ui-modal-overlay" style="display:none" @click=${handleBackdropClick}>
         <div class="a2ui-modal-content">
           ${contentId ? renderComponent(contentId, surface, scope) : nothing}
         </div>
@@ -455,17 +455,19 @@ function renderChildren(
 function renderTemplate(
   template: { componentId: string; dataBinding: string },
   surface: Surface,
-  _scope?: string,
+  scope?: string,
 ): Array<TemplateResult | typeof nothing> {
   const bindingPath = template.dataBinding;
-  const dataAtPath = getAtPath(surface.data, bindingPath);
+  // Resolve relative bindings against parent scope
+  const fullPath = bindingPath.startsWith('/')
+    ? bindingPath
+    : (scope ? `${scope}/${bindingPath}` : `/${bindingPath}`);
+  const dataAtPath = getAtPath(surface.data, fullPath);
   if (!dataAtPath || typeof dataAtPath !== 'object') return [];
 
   const items = Object.keys(dataAtPath as Record<string, unknown>);
   return items.map((key, index) => {
-    const itemScope = bindingPath.startsWith('/')
-      ? `${bindingPath}/${key}`
-      : `/${bindingPath}/${key}`;
+    const itemScope = `${fullPath}/${key}`;
     return renderComponent(template.componentId, surface, itemScope, index);
   });
 }

--- a/client/src/styles.ts
+++ b/client/src/styles.ts
@@ -443,6 +443,147 @@ export const appStyles = css`
     color: #656d76;
   }
 
+  /* Side-by-side diff grid */
+  .a2ui-diff--split {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0 1px;
+    background: #e0e0e0;
+  }
+
+  .a2ui-diff-row {
+    display: contents;
+  }
+
+  .a2ui-diff-col {
+    padding: 1px 8px;
+    font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
+    font-size: 0.8rem;
+    white-space: pre;
+    min-height: 1.5em;
+    line-height: 1.5;
+    background: #f6f8fa;
+  }
+
+  .a2ui-diff-col--del {
+    background: #ffebe9;
+    color: #cf222e;
+  }
+
+  .a2ui-diff-col--add {
+    background: #dafbe1;
+    color: #1a7f37;
+  }
+
+  .a2ui-diff-col--ctx {
+    grid-column: 1 / -1;
+    color: #656d76;
+  }
+
+  .a2ui-diff-col--empty {
+    background: #f6f8fa;
+  }
+
+  /* Severity bar */
+  .severity-bar {
+    display: flex;
+    height: 8px;
+    border-radius: 4px;
+    overflow: hidden;
+    margin-bottom: 16px;
+  }
+
+  .severity-bar__segment {
+    min-width: 0;
+    transition: width 0.3s ease;
+  }
+
+  .severity-bar__segment--critical {
+    background: #cf222e;
+  }
+
+  .severity-bar__segment--warning {
+    background: #bf8700;
+  }
+
+  .severity-bar__segment--info {
+    background: #0969da;
+  }
+
+  /* Toast notification */
+  .toast {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    background: white;
+    border-radius: 12px;
+    padding: 16px 20px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+    z-index: 10000;
+    max-width: 400px;
+    animation: slideInRight 0.3s ease-out both;
+  }
+
+  .toast--hidden {
+    display: none;
+  }
+
+  .toast--dismissing {
+    animation: slideOutRight 0.2s ease-in forwards;
+  }
+
+  .toast__icon .material-icons {
+    color: #1a7f37;
+    font-size: 24px;
+  }
+
+  .toast__content {
+    flex: 1;
+  }
+
+  .toast__message {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: #1a1a2e;
+  }
+
+  .toast__link {
+    font-size: 0.8rem;
+    color: #1a73e8;
+    text-decoration: none;
+    margin-top: 4px;
+    display: block;
+  }
+
+  .toast__link:hover {
+    text-decoration: underline;
+  }
+
+  .toast__close {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: #666;
+    padding: 4px;
+  }
+
+  .toast__close:hover {
+    color: #1a1a2e;
+  }
+
+  @keyframes slideInRight {
+    from { opacity: 0; transform: translateX(100px); }
+    to { opacity: 1; transform: translateX(0); }
+  }
+
+  @keyframes slideOutRight {
+    from { opacity: 1; transform: translateX(0); }
+    to { opacity: 0; transform: translateX(100px); }
+  }
+
   /* Severity count colors */
   .a2ui-count--critical {
     color: #cf222e;

--- a/client/src/styles.ts
+++ b/client/src/styles.ts
@@ -255,6 +255,22 @@ export const appStyles = css`
     border-color: #1557b0;
   }
 
+  /* Material Icons - must be defined in shadow DOM since external stylesheets can't cross the boundary */
+  .material-icons {
+    font-family: 'Material Icons';
+    font-weight: normal;
+    font-style: normal;
+    display: inline-block;
+    line-height: 1;
+    letter-spacing: normal;
+    text-transform: none;
+    white-space: nowrap;
+    word-wrap: normal;
+    direction: ltr;
+    -webkit-font-feature-settings: 'liga';
+    -webkit-font-smoothing: antialiased;
+  }
+
   .a2ui-icon {
     font-size: 20px;
     vertical-align: middle;

--- a/client/src/styles.ts
+++ b/client/src/styles.ts
@@ -281,6 +281,104 @@ export const appStyles = css`
     color: #856404;
   }
 
+  /* Tabs */
+  .a2ui-tabs {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .a2ui-tabs__header {
+    display: flex;
+    gap: 0;
+    border-bottom: 2px solid #e0e0e0;
+    margin-bottom: 12px;
+  }
+
+  .a2ui-tabs__tab {
+    padding: 10px 20px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font-size: 0.875rem;
+    font-weight: 500;
+    font-family: inherit;
+    color: #666;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -2px;
+    transition: color 0.15s, border-color 0.15s;
+  }
+
+  .a2ui-tabs__tab:hover {
+    color: #1a73e8;
+  }
+
+  .a2ui-tabs__tab--active {
+    color: #1a73e8;
+    border-bottom-color: #1a73e8;
+    font-weight: 600;
+  }
+
+  .a2ui-tabs__panel {
+    /* visible by default */
+  }
+
+  .a2ui-tabs__panel--hidden {
+    display: none;
+  }
+
+  /* Modal */
+  .a2ui-modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: fadeIn 0.15s ease-out;
+  }
+
+  .a2ui-modal-content {
+    background: white;
+    border-radius: 12px;
+    padding: 24px;
+    max-width: 480px;
+    width: 90%;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+    animation: fadeInUp 0.2s ease-out;
+  }
+
+  @keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
+  /* CheckBox */
+  .a2ui-checkbox {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .a2ui-checkbox input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    accent-color: #1a73e8;
+    cursor: pointer;
+    margin: 0;
+  }
+
+  .a2ui-checkbox__label {
+    font-size: 0.875rem;
+    color: #1a1a2e;
+  }
+
   .surface-container {
     background: #f0f2f5;
     border-radius: 12px;

--- a/client/src/styles.ts
+++ b/client/src/styles.ts
@@ -166,6 +166,16 @@ export const appStyles = css`
     margin: 0;
   }
 
+  .a2ui-text--link {
+    color: #1a73e8;
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  .a2ui-text--link:hover {
+    text-decoration: underline;
+  }
+
   .a2ui-column {
     display: flex;
     flex-direction: column;

--- a/server/a2ui_examples.py
+++ b/server/a2ui_examples.py
@@ -11,13 +11,24 @@ Generate one finding card per issue found in the diff.
 Populate the dataModelUpdate with actual findings from your analysis.
 Include pr_url_raw in the data model so buttons can reference it.
 
+Key features:
+- Tabs for filtering by severity (All / Critical / Warning / Info) with counts in titles
+- Findings grouped by file with a file header card
+- CheckBox on each finding for selective posting
+- Modal confirmation before posting selected findings
+- GitHub links on each finding pointing to the exact file/lines
+- Data model uses nested /files/{fileKey}/findings/{findingKey} structure
+- Separate filtered lists: /findings_all, /findings_critical, /findings_warning, /findings_info
+  each containing the same nested file > findings structure but filtered by severity
+
 [
   {"surfaceUpdate": {
     "surfaceId": "review",
     "components": [
-      {"id": "root-col", "component": {"Column": {"children": {"explicitList": ["pr-title", "pr-meta", "summary-card", "divider-1", "findings-list", "divider-2", "post-all-row"]}}}},
+      {"id": "root-col", "component": {"Column": {"children": {"explicitList": ["pr-title", "pr-meta", "summary-card", "divider-1", "severity-tabs", "divider-2", "post-modal"]}}}},
       {"id": "pr-title", "component": {"Text": {"text": {"path": "/pr_title"}, "usageHint": "h1"}}},
       {"id": "pr-meta", "component": {"Text": {"text": {"path": "/pr_meta"}, "usageHint": "caption"}}},
+
       {"id": "summary-card", "component": {"Card": {"child": "summary-row"}}},
       {"id": "summary-row", "component": {"Row": {"children": {"explicitList": ["critical-col", "warning-col", "info-col"]}, "distribution": "spaceEvenly"}}},
       {"id": "critical-col", "component": {"Column": {"children": {"explicitList": ["critical-icon", "critical-count", "critical-label"]}, "alignment": "center"}}},
@@ -32,26 +43,60 @@ Include pr_url_raw in the data model so buttons can reference it.
       {"id": "info-icon", "component": {"Icon": {"name": "info"}}},
       {"id": "info-count", "component": {"Text": {"text": {"path": "/info_count"}, "usageHint": "h2"}}},
       {"id": "info-label", "component": {"Text": {"text": {"literalString": "Info"}, "usageHint": "caption"}}},
+
       {"id": "divider-1", "component": {"Divider": {}}},
-      {"id": "findings-list", "component": {"List": {"direction": "vertical", "children": {"template": {"componentId": "finding-card", "dataBinding": "/findings"}}}}},
+
+      {"id": "severity-tabs", "component": {"Tabs": {"tabItems": [
+        {"title": {"path": "/tab_all_title"}, "child": "tab-all-content"},
+        {"title": {"path": "/tab_critical_title"}, "child": "tab-critical-content"},
+        {"title": {"path": "/tab_warning_title"}, "child": "tab-warning-content"},
+        {"title": {"path": "/tab_info_title"}, "child": "tab-info-content"}
+      ]}}},
+
+      {"id": "tab-all-content", "component": {"List": {"direction": "vertical", "children": {"template": {"componentId": "file-group-card", "dataBinding": "/findings_all"}}}}},
+      {"id": "tab-critical-content", "component": {"List": {"direction": "vertical", "children": {"template": {"componentId": "file-group-card", "dataBinding": "/findings_critical"}}}}},
+      {"id": "tab-warning-content", "component": {"List": {"direction": "vertical", "children": {"template": {"componentId": "file-group-card", "dataBinding": "/findings_warning"}}}}},
+      {"id": "tab-info-content", "component": {"List": {"direction": "vertical", "children": {"template": {"componentId": "file-group-card", "dataBinding": "/findings_info"}}}}},
+
+      {"id": "file-group-card", "component": {"Card": {"child": "file-group-col"}}},
+      {"id": "file-group-col", "component": {"Column": {"children": {"explicitList": ["file-group-header", "file-findings-list"]}}}},
+      {"id": "file-group-header", "component": {"Row": {"children": {"explicitList": ["file-icon", "file-group-name", "file-issue-count"]}, "alignment": "center"}}},
+      {"id": "file-icon", "component": {"Icon": {"name": "folder"}}},
+      {"id": "file-group-name", "weight": 1, "component": {"Text": {"text": {"path": "file_path"}, "usageHint": "h3"}}},
+      {"id": "file-issue-count", "component": {"Text": {"text": {"path": "issue_count"}, "usageHint": "caption"}}},
+
+      {"id": "file-findings-list", "component": {"List": {"direction": "vertical", "children": {"template": {"componentId": "finding-card", "dataBinding": "findings"}}}}},
+
       {"id": "finding-card", "component": {"Card": {"child": "finding-col"}}},
       {"id": "finding-col", "component": {"Column": {"children": {"explicitList": ["finding-header", "finding-diff", "finding-desc", "finding-actions"]}}}},
-      {"id": "finding-header", "component": {"Row": {"children": {"explicitList": ["severity-icon", "file-path"]}, "alignment": "center"}}},
+      {"id": "finding-header", "component": {"Row": {"children": {"explicitList": ["finding-checkbox", "severity-icon", "finding-location", "github-link-text"]}, "alignment": "center"}}},
+      {"id": "finding-checkbox", "component": {"CheckBox": {"label": {"literalString": ""}, "value": {"path": "selected"}}}},
       {"id": "severity-icon", "component": {"Icon": {"name": {"path": "severity_icon"}}}},
-      {"id": "file-path", "weight": 1, "component": {"Text": {"text": {"path": "file_path"}, "usageHint": "h3"}}},
+      {"id": "finding-location", "weight": 1, "component": {"Text": {"text": {"path": "file_path"}, "usageHint": "h4"}}},
+      {"id": "github-link-text", "component": {"Text": {"text": {"path": "github_url"}, "usageHint": "caption"}}},
       {"id": "finding-diff", "component": {"Text": {"text": {"path": "diff_snippet"}, "usageHint": "body"}}},
       {"id": "finding-desc", "component": {"Text": {"text": {"path": "description"}, "usageHint": "body"}}},
-      {"id": "finding-actions", "component": {"Row": {"children": {"explicitList": ["post-btn", "address-btn", "dismiss-btn"]}, "distribution": "end"}}},
-      {"id": "post-text", "component": {"Text": {"text": {"literalString": "Post to PR"}}}},
-      {"id": "post-btn", "component": {"Button": {"child": "post-text", "primary": true, "action": {"name": "post_review", "context": [{"key": "prUrl", "value": {"path": "/pr_url_raw"}}, {"key": "findingId", "value": {"path": "id"}}, {"key": "filePath", "value": {"path": "file_path"}}, {"key": "description", "value": {"path": "description"}}]}}}},
+      {"id": "finding-actions", "component": {"Row": {"children": {"explicitList": ["address-btn", "dismiss-btn"]}, "distribution": "end"}}},
+
       {"id": "address-text", "component": {"Text": {"text": {"literalString": "Will Address"}}}},
       {"id": "address-btn", "component": {"Button": {"child": "address-text", "action": {"name": "address_finding", "context": [{"key": "findingId", "value": {"path": "id"}}, {"key": "filePath", "value": {"path": "file_path"}}]}}}},
       {"id": "dismiss-text", "component": {"Text": {"text": {"literalString": "Dismiss"}}}},
       {"id": "dismiss-btn", "component": {"Button": {"child": "dismiss-text", "action": {"name": "dismiss_finding", "context": [{"key": "findingId", "value": {"path": "id"}}, {"key": "filePath", "value": {"path": "file_path"}}]}}}},
+
       {"id": "divider-2", "component": {"Divider": {}}},
-      {"id": "post-all-row", "component": {"Row": {"children": {"explicitList": ["post-all-btn"]}, "distribution": "center"}}},
-      {"id": "post-all-text", "component": {"Text": {"text": {"literalString": "Post All Findings as Review"}}}},
-      {"id": "post-all-btn", "component": {"Button": {"child": "post-all-text", "primary": true, "action": {"name": "post_review", "context": [{"key": "prUrl", "value": {"path": "/pr_url_raw"}}, {"key": "findings", "value": {"path": "/findings_json"}}]}}}}
+
+      {"id": "post-modal", "component": {"Modal": {"entryPointChild": "post-selected-btn", "contentChild": "modal-content-col"}}},
+      {"id": "post-selected-text", "component": {"Text": {"text": {"path": "/post_selected_label"}}}},
+      {"id": "post-selected-btn", "component": {"Button": {"child": "post-selected-text", "primary": true}}},
+
+      {"id": "modal-content-col", "component": {"Column": {"children": {"explicitList": ["modal-title", "modal-message", "modal-actions"]}, "alignment": "stretch"}}},
+      {"id": "modal-title", "component": {"Text": {"text": {"literalString": "Post Review to GitHub?"}, "usageHint": "h3"}}},
+      {"id": "modal-message", "component": {"Text": {"text": {"path": "/modal_message"}, "usageHint": "body"}}},
+      {"id": "modal-actions", "component": {"Row": {"children": {"explicitList": ["modal-cancel-btn", "modal-confirm-btn"]}, "distribution": "end"}}},
+      {"id": "modal-cancel-text", "component": {"Text": {"text": {"literalString": "Cancel"}}}},
+      {"id": "modal-cancel-btn", "component": {"Button": {"child": "modal-cancel-text", "action": {"name": "modal_cancel"}}}},
+      {"id": "modal-confirm-text", "component": {"Text": {"text": {"literalString": "Confirm & Post"}}}},
+      {"id": "modal-confirm-btn", "component": {"Button": {"child": "modal-confirm-text", "primary": true, "action": {"name": "post_selected", "context": [{"key": "prUrl", "value": {"path": "/pr_url_raw"}}, {"key": "selectedFindings", "value": {"path": "/findings_json"}}]}}}}
     ]
   }},
   {"dataModelUpdate": {
@@ -65,22 +110,79 @@ Include pr_url_raw in the data model so buttons can reference it.
       {"key": "critical_count", "valueString": "1"},
       {"key": "warning_count", "valueString": "1"},
       {"key": "info_count", "valueString": "0"},
-      {"key": "findings", "valueMap": [
-        {"key": "finding1", "valueMap": [
-          {"key": "id", "valueString": "1"},
-          {"key": "severity_icon", "valueString": "error"},
-          {"key": "file_path", "valueString": "src/auth.py:45-52"},
-          {"key": "diff_snippet", "valueString": "- if user:\\n+ if user is not None:"},
-          {"key": "description", "valueString": "Missing explicit null check. `if user` evaluates falsy for empty strings and zero, potentially allowing unauthorized access."}
+      {"key": "tab_all_title", "valueString": "All (2)"},
+      {"key": "tab_critical_title", "valueString": "Critical (1)"},
+      {"key": "tab_warning_title", "valueString": "Warning (1)"},
+      {"key": "tab_info_title", "valueString": "Info (0)"},
+      {"key": "post_selected_label", "valueString": "Post Selected (2)"},
+      {"key": "modal_message", "valueString": "2 findings will be posted as inline comments on the PR."},
+      {"key": "findings_all", "valueMap": [
+        {"key": "file_auth", "valueMap": [
+          {"key": "file_path", "valueString": "src/auth.py"},
+          {"key": "issue_count", "valueString": "1 issue"},
+          {"key": "findings", "valueMap": [
+            {"key": "f1", "valueMap": [
+              {"key": "id", "valueString": "1"},
+              {"key": "severity_icon", "valueString": "error"},
+              {"key": "file_path", "valueString": "src/auth.py:45-52"},
+              {"key": "github_url", "valueString": "View on GitHub"},
+              {"key": "diff_snippet", "valueString": "- if user:\\n+ if user is not None:"},
+              {"key": "description", "valueString": "Missing explicit null check. `if user` evaluates falsy for empty strings and zero, potentially allowing unauthorized access."},
+              {"key": "selected", "valueBoolean": true}
+            ]}
+          ]}
         ]},
-        {"key": "finding2", "valueMap": [
-          {"key": "id", "valueString": "2"},
-          {"key": "severity_icon", "valueString": "warning"},
-          {"key": "file_path", "valueString": "src/db/query.py:89-94"},
-          {"key": "diff_snippet", "valueString": "+ query = \\"SELECT * FROM users WHERE id = \\" + str(user_id)"},
-          {"key": "description", "valueString": "Potential SQL injection via string concatenation. Use parameterized queries instead."}
+        {"key": "file_db", "valueMap": [
+          {"key": "file_path", "valueString": "src/db/query.py"},
+          {"key": "issue_count", "valueString": "1 issue"},
+          {"key": "findings", "valueMap": [
+            {"key": "f2", "valueMap": [
+              {"key": "id", "valueString": "2"},
+              {"key": "severity_icon", "valueString": "warning"},
+              {"key": "file_path", "valueString": "src/db/query.py:89-94"},
+              {"key": "github_url", "valueString": "View on GitHub"},
+              {"key": "diff_snippet", "valueString": "+ query = \\"SELECT * FROM users WHERE id = \\" + str(user_id)"},
+              {"key": "description", "valueString": "Potential SQL injection via string concatenation. Use parameterized queries instead."},
+              {"key": "selected", "valueBoolean": true}
+            ]}
+          ]}
         ]}
-      ]}
+      ]},
+      {"key": "findings_critical", "valueMap": [
+        {"key": "file_auth", "valueMap": [
+          {"key": "file_path", "valueString": "src/auth.py"},
+          {"key": "issue_count", "valueString": "1 issue"},
+          {"key": "findings", "valueMap": [
+            {"key": "f1", "valueMap": [
+              {"key": "id", "valueString": "1"},
+              {"key": "severity_icon", "valueString": "error"},
+              {"key": "file_path", "valueString": "src/auth.py:45-52"},
+              {"key": "github_url", "valueString": "View on GitHub"},
+              {"key": "diff_snippet", "valueString": "- if user:\\n+ if user is not None:"},
+              {"key": "description", "valueString": "Missing explicit null check. `if user` evaluates falsy for empty strings and zero, potentially allowing unauthorized access."},
+              {"key": "selected", "valueBoolean": true}
+            ]}
+          ]}
+        ]}
+      ]},
+      {"key": "findings_warning", "valueMap": [
+        {"key": "file_db", "valueMap": [
+          {"key": "file_path", "valueString": "src/db/query.py"},
+          {"key": "issue_count", "valueString": "1 issue"},
+          {"key": "findings", "valueMap": [
+            {"key": "f2", "valueMap": [
+              {"key": "id", "valueString": "2"},
+              {"key": "severity_icon", "valueString": "warning"},
+              {"key": "file_path", "valueString": "src/db/query.py:89-94"},
+              {"key": "github_url", "valueString": "View on GitHub"},
+              {"key": "diff_snippet", "valueString": "+ query = \\"SELECT * FROM users WHERE id = \\" + str(user_id)"},
+              {"key": "description", "valueString": "Potential SQL injection via string concatenation. Use parameterized queries instead."},
+              {"key": "selected", "valueBoolean": true}
+            ]}
+          ]}
+        ]}
+      ]},
+      {"key": "findings_info", "valueMap": []}
     ]
   }},
   {"beginRendering": {"surfaceId": "review", "root": "root-col", "styles": {"primaryColor": "#1a73e8", "font": "Roboto"}}}

--- a/server/a2ui_examples.py
+++ b/server/a2ui_examples.py
@@ -118,7 +118,7 @@ Key features:
               {"key": "id", "valueString": "1"},
               {"key": "severity_icon", "valueString": "error"},
               {"key": "file_path", "valueString": "src/auth.py:45-52"},
-              {"key": "github_url", "valueString": "View on GitHub"},
+              {"key": "github_url", "valueString": "https://github.com/owner/repo/blob/abc123/src/auth.py#L45-L52"},
               {"key": "diff_snippet", "valueString": "- if user:\\n+ if user is not None:"},
               {"key": "description", "valueString": "Missing explicit null check. `if user` evaluates falsy for empty strings and zero, potentially allowing unauthorized access."},
               {"key": "selected", "valueBoolean": true}
@@ -133,7 +133,7 @@ Key features:
               {"key": "id", "valueString": "2"},
               {"key": "severity_icon", "valueString": "warning"},
               {"key": "file_path", "valueString": "src/db/query.py:89-94"},
-              {"key": "github_url", "valueString": "View on GitHub"},
+              {"key": "github_url", "valueString": "https://github.com/owner/repo/blob/abc123/src/auth.py#L45-L52"},
               {"key": "diff_snippet", "valueString": "+ query = \\"SELECT * FROM users WHERE id = \\" + str(user_id)"},
               {"key": "description", "valueString": "Potential SQL injection via string concatenation. Use parameterized queries instead."},
               {"key": "selected", "valueBoolean": true}
@@ -150,7 +150,7 @@ Key features:
               {"key": "id", "valueString": "1"},
               {"key": "severity_icon", "valueString": "error"},
               {"key": "file_path", "valueString": "src/auth.py:45-52"},
-              {"key": "github_url", "valueString": "View on GitHub"},
+              {"key": "github_url", "valueString": "https://github.com/owner/repo/blob/abc123/src/auth.py#L45-L52"},
               {"key": "diff_snippet", "valueString": "- if user:\\n+ if user is not None:"},
               {"key": "description", "valueString": "Missing explicit null check. `if user` evaluates falsy for empty strings and zero, potentially allowing unauthorized access."},
               {"key": "selected", "valueBoolean": true}
@@ -167,7 +167,7 @@ Key features:
               {"key": "id", "valueString": "2"},
               {"key": "severity_icon", "valueString": "warning"},
               {"key": "file_path", "valueString": "src/db/query.py:89-94"},
-              {"key": "github_url", "valueString": "View on GitHub"},
+              {"key": "github_url", "valueString": "https://github.com/owner/repo/blob/abc123/src/auth.py#L45-L52"},
               {"key": "diff_snippet", "valueString": "+ query = \\"SELECT * FROM users WHERE id = \\" + str(user_id)"},
               {"key": "description", "valueString": "Potential SQL injection via string concatenation. Use parameterized queries instead."},
               {"key": "selected", "valueBoolean": true}

--- a/server/a2ui_examples.py
+++ b/server/a2ui_examples.py
@@ -216,31 +216,32 @@ Show a brief response with relevant information.
 ---BEGIN POST_REVIEW_RESULT_EXAMPLE---
 Use this template after successfully posting a review to GitHub via the post_github_review tool.
 Show the review URL and count of comments posted.
+IMPORTANT: Use surfaceId "review" to replace the existing review dashboard in-place.
 
 [
   {"surfaceUpdate": {
-    "surfaceId": "post-result",
+    "surfaceId": "review",
     "components": [
       {"id": "result-col", "component": {"Column": {"children": {"explicitList": ["result-card"]}}}},
       {"id": "result-card", "component": {"Card": {"child": "result-card-col"}}},
       {"id": "result-card-col", "component": {"Column": {"children": {"explicitList": ["result-icon-row", "result-message", "result-link"]}}}},
       {"id": "result-icon-row", "component": {"Row": {"children": {"explicitList": ["result-icon", "result-title"]}, "alignment": "center"}}},
       {"id": "result-icon", "component": {"Icon": {"name": "check"}}},
-      {"id": "result-title", "component": {"Text": {"text": {"path": "/result_title"}, "usageHint": "h3"}}},
+      {"id": "result-title", "component": {"Text": {"text": {"path": "/result_title"}, "usageHint": "h2"}}},
       {"id": "result-message", "component": {"Text": {"text": {"path": "/result_message"}, "usageHint": "body"}}},
       {"id": "result-link", "component": {"Text": {"text": {"path": "/result_link"}, "usageHint": "caption"}}}
     ]
   }},
   {"dataModelUpdate": {
-    "surfaceId": "post-result",
+    "surfaceId": "review",
     "path": "/",
     "contents": [
       {"key": "result_title", "valueString": "Review Posted"},
       {"key": "result_message", "valueString": "Successfully posted 3 comments to the PR."},
-      {"key": "result_link", "valueString": "View on GitHub: https://github.com/owner/repo/pull/42#pullrequestreview-12345"}
+      {"key": "result_link", "valueString": "https://github.com/owner/repo/pull/42#pullrequestreview-12345"}
     ]
   }},
-  {"beginRendering": {"surfaceId": "post-result", "root": "result-col", "styles": {"primaryColor": "#1a73e8", "font": "Roboto"}}}
+  {"beginRendering": {"surfaceId": "review", "root": "result-col", "styles": {"primaryColor": "#1a73e8", "font": "Roboto"}}}
 ]
 ---END POST_REVIEW_RESULT_EXAMPLE---
 """

--- a/server/a2ui_examples.py
+++ b/server/a2ui_examples.py
@@ -68,7 +68,7 @@ Key features:
       {"id": "file-findings-list", "component": {"List": {"direction": "vertical", "children": {"template": {"componentId": "finding-card", "dataBinding": "findings"}}}}},
 
       {"id": "finding-card", "component": {"Card": {"child": "finding-col"}}},
-      {"id": "finding-col", "component": {"Column": {"children": {"explicitList": ["finding-header", "finding-diff", "finding-desc", "finding-actions"]}}}},
+      {"id": "finding-col", "component": {"Column": {"children": {"explicitList": ["finding-header", "finding-diff", "finding-desc"]}}}},
       {"id": "finding-header", "component": {"Row": {"children": {"explicitList": ["finding-checkbox", "severity-icon", "finding-location", "github-link-text"]}, "alignment": "center"}}},
       {"id": "finding-checkbox", "component": {"CheckBox": {"label": {"literalString": ""}, "value": {"path": "selected"}}}},
       {"id": "severity-icon", "component": {"Icon": {"name": {"path": "severity_icon"}}}},
@@ -76,13 +76,6 @@ Key features:
       {"id": "github-link-text", "component": {"Text": {"text": {"path": "github_url"}, "usageHint": "caption"}}},
       {"id": "finding-diff", "component": {"Text": {"text": {"path": "diff_snippet"}, "usageHint": "body"}}},
       {"id": "finding-desc", "component": {"Text": {"text": {"path": "description"}, "usageHint": "body"}}},
-      {"id": "finding-actions", "component": {"Row": {"children": {"explicitList": ["address-btn", "dismiss-btn"]}, "distribution": "end"}}},
-
-      {"id": "address-text", "component": {"Text": {"text": {"literalString": "Will Address"}}}},
-      {"id": "address-btn", "component": {"Button": {"child": "address-text", "action": {"name": "address_finding", "context": [{"key": "findingId", "value": {"path": "id"}}, {"key": "filePath", "value": {"path": "file_path"}}]}}}},
-      {"id": "dismiss-text", "component": {"Text": {"text": {"literalString": "Dismiss"}}}},
-      {"id": "dismiss-btn", "component": {"Button": {"child": "dismiss-text", "action": {"name": "dismiss_finding", "context": [{"key": "findingId", "value": {"path": "id"}}, {"key": "filePath", "value": {"path": "file_path"}}]}}}},
-
       {"id": "divider-2", "component": {"Divider": {}}},
 
       {"id": "post-modal", "component": {"Modal": {"entryPointChild": "post-selected-btn", "contentChild": "modal-content-col"}}},
@@ -190,9 +183,8 @@ Key features:
 ---END REVIEW_DASHBOARD_EXAMPLE---
 
 ---BEGIN FINDING_RESPONSE_EXAMPLE---
-Use this template when the user clicks "Will Address" or "Dismiss" on a finding,
-or when answering follow-up questions about specific findings or code.
-Show a brief confirmation and status update.
+Use this template when answering follow-up questions about specific findings or code.
+Show a brief response with relevant information.
 
 [
   {"surfaceUpdate": {

--- a/server/a2ui_examples.py
+++ b/server/a2ui_examples.py
@@ -17,7 +17,7 @@ Key features:
 - CheckBox on each finding for selective posting
 - Modal confirmation before posting selected findings
 - GitHub links on each finding pointing to the exact file/lines
-- Data model uses nested /files/{fileKey}/findings/{findingKey} structure
+- Data model uses nested /files/FILE_KEY/findings/FINDING_KEY structure
 - Separate filtered lists: /findings_all, /findings_critical, /findings_warning, /findings_info
   each containing the same nested file > findings structure but filtered by severity
 

--- a/server/agent_executor.py
+++ b/server/agent_executor.py
@@ -83,6 +83,25 @@ class CodeReviewAgentExecutor(AgentExecutor):
                     f"event='COMMENT'. "
                     "After posting, show a confirmation using the POST_REVIEW_RESULT_EXAMPLE template."
                 )
+            elif action == "toggle_finding":
+                finding_id = ctx.get("findingId", "unknown")
+                selected = ctx.get("selected", True)
+                status = "selected" if selected else "deselected"
+                query = (
+                    f"The user {status} finding #{finding_id} for review posting. "
+                    "No UI update needed — just acknowledge."
+                )
+            elif action == "post_selected":
+                pr_url = ctx.get("prUrl", "")
+                findings = ctx.get("selectedFindings", "[]")
+                query = (
+                    f"The user wants to post SELECTED review findings to the GitHub PR. "
+                    f"Call the `post_github_review` tool with pr_url='{pr_url}', "
+                    f"review_body='AI Code Review - selected findings from analysis', "
+                    f"findings_json='{findings}', "
+                    f"event='COMMENT'. "
+                    "After posting, show a confirmation using the POST_REVIEW_RESULT_EXAMPLE template."
+                )
             else:
                 query = f"User action: {action} with context: {ctx}"
         else:

--- a/server/agent_executor.py
+++ b/server/agent_executor.py
@@ -58,21 +58,7 @@ class CodeReviewAgentExecutor(AgentExecutor):
             ctx = ui_event_part.get("context", {})
             logger.info(f"UI action: {action}, context: {ctx}")
 
-            if action == "address_finding":
-                finding_id = ctx.get("findingId", "unknown")
-                file_path = ctx.get("filePath", "unknown file")
-                query = (
-                    f"The user chose to ADDRESS finding #{finding_id} in {file_path}. "
-                    "Acknowledge this decision with a brief confirmation using the FINDING_RESPONSE_EXAMPLE template."
-                )
-            elif action == "dismiss_finding":
-                finding_id = ctx.get("findingId", "unknown")
-                file_path = ctx.get("filePath", "unknown file")
-                query = (
-                    f"The user DISMISSED finding #{finding_id} in {file_path}. "
-                    "Acknowledge this with a brief confirmation using the FINDING_RESPONSE_EXAMPLE template."
-                )
-            elif action == "post_review":
+            if action == "post_review":
                 pr_url = ctx.get("prUrl", "")
                 findings = ctx.get("findings", "[]")
                 query = (

--- a/server/prompt_builder.py
+++ b/server/prompt_builder.py
@@ -25,7 +25,6 @@ To generate the response, you MUST follow these rules:
   github_url (display text like "View on GitHub"), selected (boolean, default true).
   IMPORTANT: Set pr_url_raw to the original PR URL so buttons can reference it.
   Set findings_json to a JSON array string of all selected findings (for the Post Selected button).
-- For "address_finding" or "dismiss_finding" actions: Use FINDING_RESPONSE_EXAMPLE template.
 - For "post_review" or "post_selected" action results (after calling post_github_review): Use POST_REVIEW_RESULT_EXAMPLE template.
 - For "toggle_finding" actions: Acknowledge briefly, no UI update needed.
 - For follow-up questions about specific findings or code: Use FINDING_RESPONSE_EXAMPLE template

--- a/server/prompt_builder.py
+++ b/server/prompt_builder.py
@@ -21,15 +21,48 @@ To generate the response, you MUST follow these rules:
 --- UI TEMPLATE RULES ---
 - For initial PR review (user provides a PR URL): Use REVIEW_DASHBOARD_EXAMPLE template.
   Populate findings from your analysis. Each finding needs: id, severity_icon (error/warning/info),
-  file_path (with line numbers), diff_snippet (the relevant changed lines), description (the issue).
+  file_path (with line numbers), diff_snippet (the relevant changed lines), description (the issue),
+  github_url (display text like "View on GitHub"), selected (boolean, default true).
   IMPORTANT: Set pr_url_raw to the original PR URL so buttons can reference it.
-  Set findings_json to a JSON array string of all findings (for the Post All button).
+  Set findings_json to a JSON array string of all selected findings (for the Post Selected button).
 - For "address_finding" or "dismiss_finding" actions: Use FINDING_RESPONSE_EXAMPLE template.
-- For "post_review" action results (after calling post_github_review): Use POST_REVIEW_RESULT_EXAMPLE template.
+- For "post_review" or "post_selected" action results (after calling post_github_review): Use POST_REVIEW_RESULT_EXAMPLE template.
+- For "toggle_finding" actions: Acknowledge briefly, no UI update needed.
 - For follow-up questions about specific findings or code: Use FINDING_RESPONSE_EXAMPLE template
   or plain text if a UI surface is not appropriate.
 - Limit findings to the top 5-8 most important issues. Skip trivial style issues.
 - Severity icons: "error" for critical, "warning" for warnings, "info" for informational.
+
+--- TABS ---
+- Always use 4 tabs: All, Critical, Warning, Info.
+- Tab titles MUST include counts: "All (6)", "Critical (2)", "Warning (3)", "Info (1)".
+- Store tab titles in the data model as /tab_all_title, /tab_critical_title, /tab_warning_title, /tab_info_title.
+- Each tab's content is a List with a template bound to a filtered data list.
+
+--- FILE GROUPING ---
+- Group findings by file path in the data model using nested valueMap.
+- Structure: /findings_all/{{fileKey}}/file_path, /findings_all/{{fileKey}}/issue_count, /findings_all/{{fileKey}}/findings/{{findingKey}}/...
+- Create separate filtered data lists: /findings_all, /findings_critical, /findings_warning, /findings_info.
+- Each filtered list contains only files (and their findings) matching that severity.
+
+--- CHECKBOX ---
+- Each finding has a "selected" boolean (valueBoolean) defaulting to true.
+- The CheckBox component binds to the "selected" path in the finding's scope.
+- When toggled, the client dispatches a "toggle_finding" action (fire-and-forget).
+
+--- MODAL ---
+- Wrap the "Post Selected" button in a Modal component for confirmation.
+- Modal entryPointChild = the "Post Selected" button.
+- Modal contentChild = a Column with title, message, and Cancel/Confirm buttons.
+- The Confirm button dispatches "post_selected" with prUrl and selectedFindings context.
+- Set /post_selected_label to "Post Selected (N)" where N is the count of selected findings.
+- Set /modal_message to "N findings will be posted as inline comments on the PR."
+
+--- GITHUB LINKS ---
+- Use the base_url and head_sha from the fetch_pr_diff tool result to construct GitHub URLs.
+- Format: {{base_url}}/blob/{{head_sha}}/{{file_path}}#L{{start_line}}-L{{end_line}}
+- Store the URL in each finding's github_url field as display text (e.g., "View on GitHub").
+- The client renders github_url text with caption styling.
 
 {CODE_REVIEW_EXAMPLES}
 

--- a/server/prompt_builder.py
+++ b/server/prompt_builder.py
@@ -25,7 +25,7 @@ To generate the response, you MUST follow these rules:
   github_url (display text like "View on GitHub"), selected (boolean, default true).
   IMPORTANT: Set pr_url_raw to the original PR URL so buttons can reference it.
   Set findings_json to a JSON array string of all selected findings (for the Post Selected button).
-- For "post_review" or "post_selected" action results (after calling post_github_review): Use POST_REVIEW_RESULT_EXAMPLE template.
+- For "post_review" or "post_selected" action results (after calling post_github_review): Use POST_REVIEW_RESULT_EXAMPLE template. IMPORTANT: Use surfaceId "review" to replace the dashboard.
 - For "toggle_finding" actions: Acknowledge briefly, no UI update needed.
 - For follow-up questions about specific findings or code: Use FINDING_RESPONSE_EXAMPLE template
   or plain text if a UI surface is not appropriate.

--- a/server/prompt_builder.py
+++ b/server/prompt_builder.py
@@ -41,7 +41,7 @@ To generate the response, you MUST follow these rules:
 
 --- FILE GROUPING ---
 - Group findings by file path in the data model using nested valueMap.
-- Structure: /findings_all/{{fileKey}}/file_path, /findings_all/{{fileKey}}/issue_count, /findings_all/{{fileKey}}/findings/{{findingKey}}/...
+- Structure: /findings_all/FILE_KEY/file_path, /findings_all/FILE_KEY/issue_count, /findings_all/FILE_KEY/findings/FINDING_KEY/...
 - Create separate filtered data lists: /findings_all, /findings_critical, /findings_warning, /findings_info.
 - Each filtered list contains only files (and their findings) matching that severity.
 
@@ -60,7 +60,7 @@ To generate the response, you MUST follow these rules:
 
 --- GITHUB LINKS ---
 - Use the base_url and head_sha from the fetch_pr_diff tool result to construct GitHub URLs.
-- Format: {{base_url}}/blob/{{head_sha}}/{{file_path}}#L{{start_line}}-L{{end_line}}
+- Format: BASE_URL/blob/HEAD_SHA/FILE_PATH#Lstart-Lend
 - Store the URL in each finding's github_url field as display text (e.g., "View on GitHub").
 - The client renders github_url text with caption styling.
 

--- a/server/prompt_builder.py
+++ b/server/prompt_builder.py
@@ -60,8 +60,7 @@ To generate the response, you MUST follow these rules:
 --- GITHUB LINKS ---
 - Use the base_url and head_sha from the fetch_pr_diff tool result to construct GitHub URLs.
 - Format: BASE_URL/blob/HEAD_SHA/FILE_PATH#Lstart-Lend
-- Store the URL in each finding's github_url field as display text (e.g., "View on GitHub").
-- The client renders github_url text with caption styling.
+- Store the full URL in each finding's github_url field (the client renders it as a clickable link).
 
 {CODE_REVIEW_EXAMPLES}
 

--- a/server/tools.py
+++ b/server/tools.py
@@ -156,10 +156,9 @@ def post_github_review(
         comment: dict[str, str | int] = {
             "path": path,
             "body": f"{severity_prefix}{description}",
-            "side": "RIGHT",
         }
         if line is not None:
-            comment["line"] = line
+            comment["position"] = line
 
         comments.append(comment)
 

--- a/server/tools.py
+++ b/server/tools.py
@@ -78,6 +78,8 @@ def fetch_pr_diff(pr_url: str, tool_context: ToolContext) -> str:
         "files_changed": meta.get("changed_files", 0),
         "additions": meta.get("additions", 0),
         "deletions": meta.get("deletions", 0),
+        "head_sha": meta.get("head", {}).get("sha", ""),
+        "base_url": f"https://github.com/{owner}/{repo}",
         "diff": diff_text,
     }
 
@@ -225,5 +227,7 @@ def _fetch_pr_files_fallback(
         "files_changed": meta.get("changed_files", 0),
         "additions": meta.get("additions", 0),
         "deletions": meta.get("deletions", 0),
+        "head_sha": meta.get("head", {}).get("sha", ""),
+        "base_url": f"https://github.com/{owner}/{repo}",
         "diff": "\n".join(diff_parts),
     })

--- a/server/tools.py
+++ b/server/tools.py
@@ -87,6 +87,60 @@ def fetch_pr_diff(pr_url: str, tool_context: ToolContext) -> str:
     return json.dumps(result)
 
 
+def _build_position_map(
+    owner: str, repo: str, pr_number: str, headers: dict[str, str],
+) -> dict[str, dict[int, int]]:
+    """Fetch PR files and build a mapping from (filename, line) to diff position.
+
+    Returns: {filename: {new_file_line_number: diff_position}}
+    """
+    files_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}/files"
+    try:
+        resp = requests.get(files_url, headers=headers, timeout=30)
+        resp.raise_for_status()
+        files = resp.json()
+    except requests.RequestException as e:
+        logger.warning(f"  - Failed to fetch PR files for position map: {e}")
+        return {}
+
+    position_map: dict[str, dict[int, int]] = {}
+    for f in files:
+        filename = f.get("filename", "")
+        patch = f.get("patch", "")
+        if not patch:
+            continue
+
+        file_positions: dict[int, int] = {}
+        position = 0
+        new_line = 0
+
+        for line in patch.split("\n"):
+            if line.startswith("@@"):
+                # Parse @@ -old_start,old_count +new_start,new_count @@
+                m = re.search(r"\+(\d+)", line)
+                if m:
+                    new_line = int(m.group(1)) - 1
+                position += 1
+                continue
+
+            position += 1
+
+            if line.startswith("-"):
+                pass  # Deletion — no new file line
+            elif line.startswith("+"):
+                new_line += 1
+                file_positions[new_line] = position
+            else:
+                # Context line
+                new_line += 1
+                file_positions[new_line] = position
+
+        position_map[filename] = file_positions
+
+    logger.info(f"  - Position map built for {len(position_map)} files")
+    return position_map
+
+
 def post_github_review(
     pr_url: str,
     review_body: str,
@@ -133,6 +187,9 @@ def post_github_review(
         logger.error(f"  - Failed to parse findings_json: {e}")
         findings = []
 
+    # Build position map from actual PR diff
+    position_map = _build_position_map(owner, repo, pr_number, headers)
+
     comments: list[dict[str, str | int]] = []
     for finding in findings:
         file_path_raw = finding.get("file_path", "")
@@ -152,20 +209,31 @@ def post_github_review(
             except ValueError:
                 line = None
 
-        severity_prefix = f"[{severity.upper()}] " if severity else ""
-        comment: dict[str, str | int] = {
-            "path": path,
-            "body": f"{severity_prefix}{description}",
-        }
-        if line is not None:
-            comment["position"] = line
+        severity_emoji = {"error": "\u274c", "warning": "\u26a0\ufe0f", "info": "\u2139\ufe0f"}.get(severity, "")
+        comment_body = f"{severity_emoji} **{severity.upper()}**: {description}"
 
-        comments.append(comment)
+        # Look up the real diff position
+        file_positions = position_map.get(path, {})
+        diff_position = file_positions.get(line) if line else None
+
+        if diff_position:
+            comments.append({"path": path, "body": comment_body, "position": diff_position})
+        elif line and file_positions:
+            # Line not exactly in diff — find closest line that IS in the diff
+            closest = min(file_positions.keys(), key=lambda l: abs(l - line))
+            if abs(closest - line) <= 10:
+                comments.append({"path": path, "body": comment_body, "position": file_positions[closest]})
+                logger.info(f"  - Snapped line {line} to {closest} for {path}")
+            else:
+                # Too far from any diff line — file-level comment
+                comments.append({"path": path, "body": comment_body, "subject_type": "file"})
+        else:
+            # No position data for this file
+            comments.append({"path": path, "body": comment_body, "subject_type": "file"})
 
     review_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}/reviews"
     event_value = event if event in ("APPROVE", "REQUEST_CHANGES", "COMMENT") else "COMMENT"
 
-    # Try with inline comments first, fall back to body-only if positions can't resolve
     payload: dict[str, str | list[dict[str, str | int]]] = {
         "body": review_body,
         "event": event_value,
@@ -177,38 +245,12 @@ def post_github_review(
         resp = requests.post(review_url, headers=headers, json=payload, timeout=30)
         resp.raise_for_status()
     except requests.RequestException as e:
+        error_detail = ""
         resp_obj = getattr(e, "response", None)
-        is_position_error = (
-            resp_obj is not None
-            and resp_obj.status_code == 422
-            and "osition" in resp_obj.text
-            and comments
-        )
-        if is_position_error:
-            logger.warning("  - Inline comments failed (position resolution). Falling back to body-only review.")
-            # Build a body with all findings listed
-            body_lines = [review_body, ""]
-            for c in comments:
-                body_lines.append(f"**{c['path']}** — {c['body']}")
-            fallback_payload: dict[str, str] = {
-                "body": "\n".join(body_lines),
-                "event": event_value,
-            }
-            try:
-                resp = requests.post(review_url, headers=headers, json=fallback_payload, timeout=30)
-                resp.raise_for_status()
-            except requests.RequestException as e2:
-                error_detail = ""
-                if hasattr(e2, "response") and e2.response is not None:
-                    error_detail = f" Response: {e2.response.text[:500]}"
-                logger.error(f"  - Fallback review also failed: {e2}{error_detail}")
-                return json.dumps({"error": f"Failed to post review: {e2}{error_detail}"})
-        else:
-            error_detail = ""
-            if resp_obj is not None:
-                error_detail = f" Response: {resp_obj.text[:500]}"
-            logger.error(f"  - Failed to post review: {e}{error_detail}")
-            return json.dumps({"error": f"Failed to post review: {e}{error_detail}"})
+        if resp_obj is not None:
+            error_detail = f" Response: {resp_obj.text[:500]}"
+        logger.error(f"  - Failed to post review: {e}{error_detail}")
+        return json.dumps({"error": f"Failed to post review: {e}{error_detail}"})
 
     result = resp.json()
     html_url = result.get("html_url", "")

--- a/server/tools.py
+++ b/server/tools.py
@@ -137,7 +137,7 @@ def post_github_review(
     for finding in findings:
         file_path_raw = finding.get("file_path", "")
         description = finding.get("description", "")
-        severity = finding.get("severity", "info")
+        severity = finding.get("severity_icon", finding.get("severity", "info"))
 
         # Parse "src/auth.py:45-52" -> path="src/auth.py", line=52
         path = file_path_raw

--- a/server/tools.py
+++ b/server/tools.py
@@ -231,11 +231,44 @@ def post_github_review(
             # No position data for this file
             comments.append({"path": path, "body": comment_body, "subject_type": "file"})
 
+    # Build a structured review body from findings
+    severity_counts: dict[str, int] = {"error": 0, "warning": 0, "info": 0}
+    files_affected: set[str] = set()
+    for finding in findings:
+        sev = finding.get("severity_icon", finding.get("severity", "info"))
+        severity_counts[sev] = severity_counts.get(sev, 0) + 1
+        fp = finding.get("file_path", "")
+        if ":" in fp:
+            fp = fp.rsplit(":", 1)[0]
+        files_affected.add(fp)
+
+    total = len(findings)
+    body_lines = [
+        "## AI Code Review",
+        "",
+        f"**{total} issue{'s' if total != 1 else ''}** found across **{len(files_affected)} file{'s' if len(files_affected) != 1 else ''}**",
+        "",
+        "| Severity | Count |",
+        "| --- | --- |",
+    ]
+    if severity_counts.get("error"):
+        body_lines.append(f"| ❌ Critical | {severity_counts['error']} |")
+    if severity_counts.get("warning"):
+        body_lines.append(f"| ⚠️ Warning | {severity_counts['warning']} |")
+    if severity_counts.get("info"):
+        body_lines.append(f"| ℹ️ Info | {severity_counts['info']} |")
+
+    body_lines += [
+        "",
+        "See inline comments below for details.",
+    ]
+    formatted_body = "\n".join(body_lines)
+
     review_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}/reviews"
     event_value = event if event in ("APPROVE", "REQUEST_CHANGES", "COMMENT") else "COMMENT"
 
     payload: dict[str, str | list[dict[str, str | int]]] = {
-        "body": review_body,
+        "body": formatted_body,
         "event": event_value,
     }
     if comments:

--- a/server/tools.py
+++ b/server/tools.py
@@ -163,9 +163,12 @@ def post_github_review(
         comments.append(comment)
 
     review_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}/reviews"
+    event_value = event if event in ("APPROVE", "REQUEST_CHANGES", "COMMENT") else "COMMENT"
+
+    # Try with inline comments first, fall back to body-only if positions can't resolve
     payload: dict[str, str | list[dict[str, str | int]]] = {
         "body": review_body,
-        "event": event if event in ("APPROVE", "REQUEST_CHANGES", "COMMENT") else "COMMENT",
+        "event": event_value,
     }
     if comments:
         payload["comments"] = comments
@@ -173,20 +176,48 @@ def post_github_review(
     try:
         resp = requests.post(review_url, headers=headers, json=payload, timeout=30)
         resp.raise_for_status()
-        result = resp.json()
-        html_url = result.get("html_url", "")
-        logger.info(f"  - Success: Review posted at {html_url}")
-        return json.dumps({
-            "success": True,
-            "review_url": html_url,
-            "comments_posted": len(comments),
-        })
     except requests.RequestException as e:
-        error_detail = ""
-        if hasattr(e, "response") and e.response is not None:
-            error_detail = f" Response: {e.response.text[:500]}"
-        logger.error(f"  - Failed to post review: {e}{error_detail}")
-        return json.dumps({"error": f"Failed to post review: {e}{error_detail}"})
+        resp_obj = getattr(e, "response", None)
+        is_position_error = (
+            resp_obj is not None
+            and resp_obj.status_code == 422
+            and "osition" in resp_obj.text
+            and comments
+        )
+        if is_position_error:
+            logger.warning("  - Inline comments failed (position resolution). Falling back to body-only review.")
+            # Build a body with all findings listed
+            body_lines = [review_body, ""]
+            for c in comments:
+                body_lines.append(f"**{c['path']}** — {c['body']}")
+            fallback_payload: dict[str, str] = {
+                "body": "\n".join(body_lines),
+                "event": event_value,
+            }
+            try:
+                resp = requests.post(review_url, headers=headers, json=fallback_payload, timeout=30)
+                resp.raise_for_status()
+            except requests.RequestException as e2:
+                error_detail = ""
+                if hasattr(e2, "response") and e2.response is not None:
+                    error_detail = f" Response: {e2.response.text[:500]}"
+                logger.error(f"  - Fallback review also failed: {e2}{error_detail}")
+                return json.dumps({"error": f"Failed to post review: {e2}{error_detail}"})
+        else:
+            error_detail = ""
+            if resp_obj is not None:
+                error_detail = f" Response: {resp_obj.text[:500]}"
+            logger.error(f"  - Failed to post review: {e}{error_detail}")
+            return json.dumps({"error": f"Failed to post review: {e}{error_detail}"})
+
+    result = resp.json()
+    html_url = result.get("html_url", "")
+    logger.info(f"  - Success: Review posted at {html_url}")
+    return json.dumps({
+        "success": True,
+        "review_url": html_url,
+        "comments_posted": len(comments),
+    })
 
 
 def _fetch_pr_files_fallback(


### PR DESCRIPTION
## Summary

- **Side-by-side diff**: Replaced unified +/- diff with two-column grid layout — removals on left (red), additions on right (green), context lines spanning full width
- **Severity bar**: Proportional color bar (critical/warning/info) rendered above the review dashboard from existing data model counts
- **Toast notification**: Post results now appear as a slide-in toast overlay instead of replacing the dashboard. Auto-dismisses after 4s with manual close option.

## Test plan

- [ ] Submit a PR with mixed +/- changes — verify diff shows side-by-side columns
- [ ] Verify severity bar appears above summary card with correct proportions
- [ ] Click "Post Selected" → Confirm — verify toast slides in, dashboard stays visible
- [ ] Verify toast auto-dismisses after ~4 seconds
- [ ] Verify toast close button works
- [ ] Verify "View on GitHub" link in toast opens correct URL