### PR TITLE
Add Slider, multi-surface sidebar, and review history

### DIFF
--- a/client/src/components/app-shell.ts
+++ b/client/src/components/app-shell.ts
@@ -9,6 +9,12 @@ import { appStyles } from '../styles.js';
 
 const SERVER_URL = 'http://localhost:10002';
 
+interface ReviewHistoryEntry {
+  timestamp: Date;
+  commentCount: string;
+  reviewUrl: string;
+}
+
 @customElement('app-shell')
 export class AppShell extends LitElement {
   static override styles = appStyles;
@@ -26,6 +32,8 @@ export class AppShell extends LitElement {
   @state() private toastLink = '';
   @state() private toastVisible = false;
   @state() private toastDismissing = false;
+  @state() private reviewHistory: ReviewHistoryEntry[] = [];
+  @state() private historyExpanded = true;
 
   private client: A2AClient | null = null;
   private surfaceManager = new SurfaceManager();
@@ -54,9 +62,15 @@ export class AppShell extends LitElement {
     };
 
     // Client-only actions that don't need a server round-trip
-    if (detail.name === 'toggle_finding' || detail.name === 'modal_cancel' || detail.name === 'tab_switch') {
+    if (detail.name === 'toggle_finding' || detail.name === 'modal_cancel' || detail.name === 'tab_switch' || detail.name === 'slider_change') {
       if (detail.name === 'toggle_finding') {
         this.updateSelectedCount(detail.surfaceId);
+      }
+      if (detail.name === 'slider_change') {
+        const surface = this.surfaceManager.getSurface(detail.surfaceId);
+        if (surface) {
+          surface.data.severity_threshold = Number(detail.context.value);
+        }
       }
       this.renderKey++;
       return;
@@ -227,6 +241,14 @@ export class AppShell extends LitElement {
 
         // Show toast
         this.showToast(message, link);
+
+        // Record in review history
+        const countMatch = message.match(/(\d+)/);
+        this.reviewHistory = [...this.reviewHistory, {
+          timestamp: new Date(),
+          commentCount: countMatch ? countMatch[1] : '?',
+          reviewUrl: link,
+        }];
       }
 
       this.activeSurfaces = this.surfaceManager.getReadySurfaces();
@@ -301,6 +323,47 @@ export class AppShell extends LitElement {
     }
   }
 
+  private renderMainSurface(surface: Surface) {
+    const critical = parseInt(String(surface.data.critical_count ?? ''), 10) || 0;
+    const warning = parseInt(String(surface.data.warning_count ?? ''), 10) || 0;
+    const info = parseInt(String(surface.data.info_count ?? ''), 10) || 0;
+    const total = critical + warning + info;
+    return html`
+      <div class="surface-container" key=${`${surface.surfaceId}-${this.renderKey}`}>
+        ${total > 0 ? html`
+          <div class="severity-bar">
+            <div class="severity-bar__segment severity-bar__segment--critical" style="width:${(critical / total) * 100}%"></div>
+            <div class="severity-bar__segment severity-bar__segment--warning" style="width:${(warning / total) * 100}%"></div>
+            <div class="severity-bar__segment severity-bar__segment--info" style="width:${(info / total) * 100}%"></div>
+          </div>
+        ` : nothing}
+        ${renderComponent(surface.root, surface)}
+      </div>
+    `;
+  }
+
+  private renderSurfaces() {
+    if (this.activeSurfaces.length === 0) return nothing;
+
+    const sidebar = this.activeSurfaces.find(s => s.surfaceId === 'sidebar');
+    const mainSurfaces = this.activeSurfaces.filter(s => s.surfaceId !== 'sidebar');
+
+    if (sidebar) {
+      return html`
+        <div class="surfaces-layout">
+          <div class="surface-container surface-container--sidebar" key=${`sidebar-${this.renderKey}`}>
+            ${renderComponent(sidebar.root, sidebar)}
+          </div>
+          <div class="surfaces-main">
+            ${mainSurfaces.map(surface => this.renderMainSurface(surface))}
+          </div>
+        </div>
+      `;
+    }
+
+    return mainSurfaces.map(surface => this.renderMainSurface(surface));
+  }
+
   override render() {
     return html`
       <div class="header">
@@ -343,26 +406,32 @@ export class AppShell extends LitElement {
         ? html`<div class="text-response">${this.textResponse}</div>`
         : nothing}
 
-      ${this.activeSurfaces.map(
-        (surface) => {
-          const critical = parseInt(String(surface.data.critical_count ?? ''), 10) || 0;
-          const warning = parseInt(String(surface.data.warning_count ?? ''), 10) || 0;
-          const info = parseInt(String(surface.data.info_count ?? ''), 10) || 0;
-          const total = critical + warning + info;
-          return html`
-            <div class="surface-container" key=${`${surface.surfaceId}-${this.renderKey}`}>
-              ${total > 0 ? html`
-                <div class="severity-bar">
-                  <div class="severity-bar__segment severity-bar__segment--critical" style="width:${(critical / total) * 100}%"></div>
-                  <div class="severity-bar__segment severity-bar__segment--warning" style="width:${(warning / total) * 100}%"></div>
-                  <div class="severity-bar__segment severity-bar__segment--info" style="width:${(info / total) * 100}%"></div>
+      ${this.renderSurfaces()}
+
+      ${this.reviewHistory.length > 0 ? html`
+        <div class="review-history">
+          <button class="review-history__toggle" @click=${() => { this.historyExpanded = !this.historyExpanded; }}>
+            <span class="material-icons">${this.historyExpanded ? 'expand_more' : 'chevron_right'}</span>
+            ${this.reviewHistory.length} review${this.reviewHistory.length !== 1 ? 's' : ''} posted
+          </button>
+          ${this.historyExpanded ? html`
+            <div class="review-history__list">
+              ${this.reviewHistory.map(entry => html`
+                <div class="review-history__item">
+                  <span class="material-icons">check_circle</span>
+                  <div class="review-history__meta">
+                    <div class="review-history__count">${entry.commentCount} comments posted</div>
+                    <div class="review-history__time">${entry.timestamp.toLocaleTimeString()}</div>
+                  </div>
+                  ${entry.reviewUrl ? html`
+                    <a class="review-history__link" href=${entry.reviewUrl} target="_blank" rel="noopener noreferrer">View</a>
+                  ` : nothing}
                 </div>
-              ` : nothing}
-              ${renderComponent(surface.root, surface)}
+              `)}
             </div>
-          `;
-        },
-      )}
+          ` : nothing}
+        </div>
+      ` : nothing}
 
       ${this.activeSurfaces.length > 0
         ? html`

--- a/client/src/components/app-shell.ts
+++ b/client/src/components/app-shell.ts
@@ -242,13 +242,15 @@ export class AppShell extends LitElement {
         // Show toast
         this.showToast(message, link);
 
-        // Record in review history
-        const countMatch = message.match(/(\d+)/);
-        this.reviewHistory = [...this.reviewHistory, {
-          timestamp: new Date(),
-          commentCount: countMatch ? countMatch[1] : '?',
-          reviewUrl: link,
-        }];
+        // Record in review history only on successful posts (link is a GitHub URL)
+        if (link.includes('github.com')) {
+          const countMatch = message.match(/(\d+)/);
+          this.reviewHistory = [...this.reviewHistory, {
+            timestamp: new Date(),
+            commentCount: countMatch ? countMatch[1] : '?',
+            reviewUrl: link,
+          }];
+        }
       }
 
       this.activeSurfaces = this.surfaceManager.getReadySurfaces();

--- a/client/src/components/app-shell.ts
+++ b/client/src/components/app-shell.ts
@@ -99,6 +99,7 @@ export class AppShell extends LitElement {
     this.statusHistory = [];
     this.errorText = '';
     this.textResponse = '';
+    this.scrollIntoView({ behavior: 'smooth', block: 'start' });
 
     try {
       const stream = sendUserAction(this.client, action, this.contextId, this.taskId);

--- a/client/src/renderer.ts
+++ b/client/src/renderer.ts
@@ -74,6 +74,9 @@ export function renderComponent(
     case 'CheckBox':
       content = renderCheckBox(props, surface, id, scope);
       break;
+    case 'Slider':
+      content = renderSlider(props, surface, id, scope);
+      break;
     default:
       content = html`<div class="a2ui-unknown">[Unknown: ${type}]</div>`;
   }
@@ -220,21 +223,31 @@ const SEVERITY_CARD_CLASSES: Record<string, string> = {
   info: 'a2ui-card--info',
 };
 
+const SEVERITY_RANK: Record<string, number> = { error: 2, warning: 1, info: 0 };
+
 function renderCard(
   props: Record<string, unknown>,
   surface: Surface,
   scope?: string,
   animationIndex?: number,
-): TemplateResult {
+): TemplateResult | typeof nothing {
   const childId = props.child as string;
 
   // Check scoped data for severity_icon to apply colored left border
   let severityClass = '';
+  let severityIcon: unknown;
   if (scope) {
-    const severityIcon = getAtPath(surface.data, `${scope}/severity_icon`);
+    severityIcon = getAtPath(surface.data, `${scope}/severity_icon`);
     if (typeof severityIcon === 'string' && SEVERITY_CARD_CLASSES[severityIcon]) {
       severityClass = ` ${SEVERITY_CARD_CLASSES[severityIcon]}`;
     }
+  }
+
+  // Filter by severity threshold — only hide individual finding cards (those with both scope and severityClass)
+  if (scope && severityClass) {
+    const threshold = Number(surface.data.severity_threshold ?? 0);
+    const rank = SEVERITY_RANK[String(severityIcon)] ?? 0;
+    if (rank < threshold) return nothing;
   }
 
   const delayStyle = animationIndex !== undefined
@@ -485,6 +498,63 @@ function renderCheckBox(
       <input type="checkbox" .checked=${checked} @change=${handleChange} />
       ${label ? html`<span class="a2ui-checkbox__label">${label}</span>` : nothing}
     </label>
+  `;
+}
+
+const SLIDER_LABELS: Record<number, string> = {
+  0: 'All',
+  1: 'Warning+',
+  2: 'Critical',
+};
+
+function renderSlider(
+  props: Record<string, unknown>,
+  surface: Surface,
+  componentId: string,
+  scope?: string,
+): TemplateResult {
+  const valueBinding = props.value as BoundValue | undefined;
+  const min = Number(props.minValue ?? 0);
+  const max = Number(props.maxValue ?? 100);
+  const value = valueBinding ? Number(resolveValue(valueBinding, surface.data, scope) ?? min) : min;
+  const label = SLIDER_LABELS[value] ?? String(value);
+
+  const handleInput = (e: Event) => {
+    const newValue = Number((e.target as HTMLInputElement).value);
+
+    if (valueBinding && 'path' in valueBinding) {
+      const p = valueBinding.path;
+      const fullPath = p.startsWith('/') ? p : (scope ? `${scope}/${p}` : p);
+      const segments = fullPath.replace(/^\//, '').split('/').filter(Boolean);
+      let current: Record<string, unknown> = surface.data;
+      for (let i = 0; i < segments.length - 1; i++) {
+        const seg = segments[i];
+        if (current[seg] == null || typeof current[seg] !== 'object') {
+          current[seg] = {};
+        }
+        current = current[seg] as Record<string, unknown>;
+      }
+      current[segments[segments.length - 1]] = newValue;
+    }
+
+    const event = new CustomEvent('a2ui-action', {
+      bubbles: true,
+      composed: true,
+      detail: {
+        name: 'slider_change',
+        sourceComponentId: componentId,
+        surfaceId: surface.surfaceId,
+        context: { value: newValue },
+      },
+    });
+    document.dispatchEvent(event);
+  };
+
+  return html`
+    <div class="a2ui-slider">
+      <input type="range" min=${min} max=${max} .value=${String(value)} @input=${handleInput} />
+      <span class="a2ui-slider__value">${label}</span>
+    </div>
   `;
 }
 

--- a/client/src/styles.ts
+++ b/client/src/styles.ts
@@ -3,7 +3,7 @@ import { css } from 'lit';
 export const appStyles = css`
   :host {
     display: block;
-    max-width: 800px;
+    max-width: 1060px;
     margin: 0 auto;
     padding: 24px;
     font-family: 'Roboto', system-ui, sans-serif;
@@ -405,11 +405,61 @@ export const appStyles = css`
     color: #1a1a2e;
   }
 
+  /* Slider */
+  .a2ui-slider {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .a2ui-slider input[type="range"] {
+    flex: 1;
+    accent-color: #1a73e8;
+    height: 4px;
+    cursor: pointer;
+  }
+
+  .a2ui-slider__value {
+    font-size: 0.8rem;
+    color: #666;
+    min-width: 4em;
+    text-align: center;
+  }
+
+  /* Multi-surface layout */
+  .surfaces-layout {
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    gap: 16px;
+    align-items: start;
+  }
+
+  .surfaces-main {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
   .surface-container {
     background: #f0f2f5;
     border-radius: 12px;
     padding: 20px;
     box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.06);
+  }
+
+  .surface-container--sidebar {
+    position: sticky;
+    top: 24px;
+  }
+
+  @media (max-width: 700px) {
+    .surfaces-layout {
+      grid-template-columns: 1fr;
+    }
+
+    .surface-container--sidebar {
+      position: static;
+    }
   }
 
   /* Diff block styling */
@@ -686,5 +736,79 @@ export const appStyles = css`
   .chat-row button:disabled {
     background: #a0c4f1;
     cursor: not-allowed;
+  }
+
+  /* Review history */
+  .review-history {
+    margin-top: 16px;
+    padding: 16px;
+    background: #f8f9fa;
+    border-radius: 12px;
+  }
+
+  .review-history__toggle {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    border: none;
+    background: none;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #1a1a2e;
+    padding: 0;
+    font-family: inherit;
+  }
+
+  .review-history__toggle .material-icons {
+    font-size: 18px;
+    transition: transform 0.2s;
+  }
+
+  .review-history__list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 12px;
+  }
+
+  .review-history__item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    background: white;
+    border-radius: 8px;
+    animation: fadeInUp 0.2s ease-out both;
+  }
+
+  .review-history__item .material-icons {
+    color: #1a7f37;
+    font-size: 18px;
+  }
+
+  .review-history__meta {
+    flex: 1;
+  }
+
+  .review-history__count {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: #1a1a2e;
+  }
+
+  .review-history__time {
+    font-size: 0.75rem;
+    color: #666;
+  }
+
+  .review-history__link {
+    font-size: 0.8rem;
+    color: #1a73e8;
+    text-decoration: none;
+  }
+
+  .review-history__link:hover {
+    text-decoration: underline;
   }
 `;

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,3 +1,3 @@
 GEMINI_API_KEY=
 GITHUB_TOKEN=
-LITELLM_MODEL=gemini/gemini-2.5-flash
+LITELLM_MODEL=gemini/gemini-3-flash-preview

--- a/server/a2ui_examples.py
+++ b/server/a2ui_examples.py
@@ -25,9 +25,13 @@ Key features:
   {"surfaceUpdate": {
     "surfaceId": "review",
     "components": [
-      {"id": "root-col", "component": {"Column": {"children": {"explicitList": ["pr-title", "pr-meta", "summary-card", "divider-1", "severity-tabs", "divider-2", "post-modal"]}}}},
+      {"id": "root-col", "component": {"Column": {"children": {"explicitList": ["pr-title", "pr-meta", "threshold-row", "summary-card", "divider-1", "severity-tabs", "divider-2", "post-modal"]}}}},
       {"id": "pr-title", "component": {"Text": {"text": {"path": "/pr_title"}, "usageHint": "h1"}}},
       {"id": "pr-meta", "component": {"Text": {"text": {"path": "/pr_meta"}, "usageHint": "caption"}}},
+
+      {"id": "threshold-row", "component": {"Row": {"children": {"explicitList": ["threshold-label", "threshold-slider"]}, "alignment": "center"}}},
+      {"id": "threshold-label", "component": {"Text": {"text": {"literalString": "Severity filter"}, "usageHint": "caption"}}},
+      {"id": "threshold-slider", "component": {"Slider": {"value": {"path": "/severity_threshold"}, "minValue": 0, "maxValue": 2}}},
 
       {"id": "summary-card", "component": {"Card": {"child": "summary-row"}}},
       {"id": "summary-row", "component": {"Row": {"children": {"explicitList": ["critical-col", "warning-col", "info-col"]}, "distribution": "spaceEvenly"}}},
@@ -99,6 +103,7 @@ Key features:
       {"key": "pr_title", "valueString": "Code Review: Fix auth middleware"},
       {"key": "pr_meta", "valueString": "PR #42 by @developer - 5 files changed"},
       {"key": "pr_url_raw", "valueString": "https://github.com/owner/repo/pull/42"},
+      {"key": "severity_threshold", "valueNumber": 0},
       {"key": "findings_json", "valueString": "[]"},
       {"key": "critical_count", "valueString": "1"},
       {"key": "warning_count", "valueString": "1"},
@@ -181,6 +186,46 @@ Key features:
   {"beginRendering": {"surfaceId": "review", "root": "root-col", "styles": {"primaryColor": "#1a73e8", "font": "Roboto"}}}
 ]
 ---END REVIEW_DASHBOARD_EXAMPLE---
+
+---BEGIN SIDEBAR_SURFACE_EXAMPLE---
+When generating a review dashboard, ALSO generate a sidebar surface with surfaceId "sidebar".
+The sidebar shows the list of files with issue counts from the review.
+Output the sidebar messages BEFORE the review dashboard messages, so the full JSON array has 6 messages total:
+  sidebar surfaceUpdate, sidebar dataModelUpdate, sidebar beginRendering,
+  review surfaceUpdate, review dataModelUpdate, review beginRendering.
+
+[
+  {"surfaceUpdate": {
+    "surfaceId": "sidebar",
+    "components": [
+      {"id": "sidebar-col", "component": {"Column": {"children": {"explicitList": ["sidebar-heading", "sidebar-list"]}}}},
+      {"id": "sidebar-heading", "component": {"Text": {"text": {"literalString": "Files"}, "usageHint": "h3"}}},
+      {"id": "sidebar-list", "component": {"List": {"direction": "vertical", "children": {"template": {"componentId": "sidebar-file-item", "dataBinding": "/files"}}}}},
+      {"id": "sidebar-file-item", "component": {"Row": {"children": {"explicitList": ["sidebar-file-icon", "sidebar-file-name", "sidebar-file-count"]}, "alignment": "center"}}},
+      {"id": "sidebar-file-icon", "component": {"Icon": {"name": "folder"}}},
+      {"id": "sidebar-file-name", "weight": 1, "component": {"Text": {"text": {"path": "name"}, "usageHint": "body"}}},
+      {"id": "sidebar-file-count", "component": {"Text": {"text": {"path": "count"}, "usageHint": "caption"}}}
+    ]
+  }},
+  {"dataModelUpdate": {
+    "surfaceId": "sidebar",
+    "path": "/",
+    "contents": [
+      {"key": "files", "valueMap": [
+        {"key": "file_auth", "valueMap": [
+          {"key": "name", "valueString": "src/auth.py"},
+          {"key": "count", "valueString": "1 issue"}
+        ]},
+        {"key": "file_db", "valueMap": [
+          {"key": "name", "valueString": "src/db/query.py"},
+          {"key": "count", "valueString": "1 issue"}
+        ]}
+      ]}
+    ]
+  }},
+  {"beginRendering": {"surfaceId": "sidebar", "root": "sidebar-col", "styles": {"primaryColor": "#1a73e8", "font": "Roboto"}}}
+]
+---END SIDEBAR_SURFACE_EXAMPLE---
 
 ---BEGIN FINDING_RESPONSE_EXAMPLE---
 Use this template when answering follow-up questions about specific findings or code.

--- a/server/prompt_builder.py
+++ b/server/prompt_builder.py
@@ -16,7 +16,7 @@ To generate the response, you MUST follow these rules:
 2. The first part is your brief conversational summary of findings.
 3. The second part is a single, raw JSON array of A2UI messages (no markdown fences).
 4. The JSON part MUST validate against the A2UI JSON SCHEMA provided below.
-5. The JSON array MUST contain exactly 3 messages: surfaceUpdate, dataModelUpdate, beginRendering.
+5. The JSON array MUST contain 3 messages per surface. For review dashboards, generate 6 messages total: 3 for the sidebar surface + 3 for the review surface.
 
 --- UI TEMPLATE RULES ---
 - For initial PR review (user provides a PR URL): Use REVIEW_DASHBOARD_EXAMPLE template.
@@ -56,6 +56,20 @@ To generate the response, you MUST follow these rules:
 - The Confirm button dispatches "post_selected" with prUrl and selectedFindings context.
 - Set /post_selected_label to "Post Selected (N)" where N is the count of selected findings.
 - Set /modal_message to "N findings will be posted as inline comments on the PR."
+
+--- SEVERITY SLIDER ---
+- Include a Slider component with value bound to /severity_threshold, minValue 0, maxValue 2.
+- Labels: 0 = "All", 1 = "Warning+", 2 = "Critical only".
+- Place in a Row with a caption label before the summary card.
+- Set /severity_threshold to 0 (valueNumber) in the data model.
+
+--- SIDEBAR SURFACE ---
+- Generate a SECOND surface with surfaceId "sidebar" alongside the main "review" surface.
+- The sidebar shows a file tree: heading "Files", then a List of file items.
+- Each file item has a folder icon, file name, and issue count.
+- The sidebar data comes from the same analysis — extract unique file paths and per-file issue counts.
+- Output 6 total A2UI messages: 3 for sidebar (surfaceUpdate, dataModelUpdate, beginRendering) + 3 for review.
+- Sidebar messages come FIRST in the JSON array, then review messages.
 
 --- GITHUB LINKS ---
 - Use the base_url and head_sha from the fetch_pr_diff tool result to construct GitHub URLs.

--- a/server/tools.py
+++ b/server/tools.py
@@ -191,6 +191,7 @@ def post_github_review(
     position_map = _build_position_map(owner, repo, pr_number, headers)
 
     comments: list[dict[str, str | int]] = []
+    body_only_findings: list[str] = []
     for finding in findings:
         file_path_raw = finding.get("file_path", "")
         description = finding.get("description", "")
@@ -212,24 +213,26 @@ def post_github_review(
         severity_emoji = {"error": "\u274c", "warning": "\u26a0\ufe0f", "info": "\u2139\ufe0f"}.get(severity, "")
         comment_body = f"{severity_emoji} **{severity.upper()}**: {description}"
 
-        # Look up the real diff position
+        # Look up whether this line is in the diff
         file_positions = position_map.get(path, {})
-        diff_position = file_positions.get(line) if line else None
+        resolved_line = line
 
-        if diff_position:
-            comments.append({"path": path, "body": comment_body, "position": diff_position})
-        elif line and file_positions:
-            # Line not exactly in diff — find closest line that IS in the diff
+        if line and not file_positions.get(line) and file_positions:
+            # Line not exactly in diff — snap to closest line within 10 lines
             closest = min(file_positions.keys(), key=lambda l: abs(l - line))
             if abs(closest - line) <= 10:
-                comments.append({"path": path, "body": comment_body, "position": file_positions[closest]})
+                resolved_line = closest
                 logger.info(f"  - Snapped line {line} to {closest} for {path}")
             else:
-                # Too far from any diff line — file-level comment
-                comments.append({"path": path, "body": comment_body, "subject_type": "file"})
+                resolved_line = None
+
+        if resolved_line and file_positions.get(resolved_line):
+            # Use line + side (more reliable than position-based approach)
+            comments.append({"path": path, "body": comment_body, "line": resolved_line, "side": "RIGHT"})
         else:
-            # No position data for this file
-            comments.append({"path": path, "body": comment_body, "subject_type": "file"})
+            # Line not in diff — add to review body instead of inline comment
+            body_only_findings.append(f"- {severity_emoji} **{path}:{line or '?'}** — {description}")
+            logger.info(f"  - Line {line} not in diff for {path}, adding to body")
 
     # Build a structured review body from findings
     severity_counts: dict[str, int] = {"error": 0, "warning": 0, "info": 0}
@@ -258,10 +261,12 @@ def post_github_review(
     if severity_counts.get("info"):
         body_lines.append(f"| ℹ️ Info | {severity_counts['info']} |")
 
-    body_lines += [
-        "",
-        "See inline comments below for details.",
-    ]
+    if body_only_findings:
+        body_lines += ["", "### Additional findings (not in diff)", ""]
+        body_lines += body_only_findings
+
+    if comments:
+        body_lines += ["", "See inline comments below for details."]
     formatted_body = "\n".join(body_lines)
 
     review_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}/reviews"


### PR DESCRIPTION
## Summary

Three demo-showcase features for the A2UI code review agent:
- **Slider component** — severity threshold filter that hides findings below the selected level (All / Warning+ / Critical)
- **Multi-surface layout** — sidebar file tree alongside the main review panel using CSS grid
- **Review history** — collapsible session history of posted reviews with comment count, timestamp, and GitHub link

## Changes

- Implement `renderSlider()` in renderer.ts following the CheckBox interactive pattern
- Add severity threshold filtering in `renderCard()` — cards with severity below threshold return `nothing`
- Handle `slider_change` as client-only action in app-shell.ts
- Add multi-surface layout: sidebar detection, CSS grid with sticky sidebar, responsive stacking at 700px
- Track posted reviews via `ReviewHistoryEntry[]` state, populated on toast detection
- Update LLM templates with Slider component and sidebar surface example (6-message JSON arrays)
- Update prompt rules for severity slider and sidebar generation

## Files Changed

6 files changed (+347/-25)

<details>
<summary>File list</summary>

- `client/src/renderer.ts` — Slider case + renderSlider() + severity threshold in renderCard
- `client/src/styles.ts` — Slider CSS, multi-surface grid, sidebar sticky, review history styles
- `client/src/components/app-shell.ts` — slider_change handler, renderSurfaces(), review history state + UI
- `server/a2ui_examples.py` — Slider in dashboard template, SIDEBAR_SURFACE_EXAMPLE
- `server/prompt_builder.py` — Severity slider + sidebar surface prompt sections
- `server/.env.example` — env config update

</details>

## Testing

- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] Vite production build succeeds
- [x] Server prompt builds with all new sections
- [ ] Browser validation with real PR URL