### PR TITLE
Add issue creation, address buttons, TextField & MultipleChoice

### DIFF
--- a/client/src/components/app-shell.ts
+++ b/client/src/components/app-shell.ts
@@ -11,7 +11,7 @@ const SERVER_URL = 'http://localhost:10002';
 
 interface ReviewHistoryEntry {
   timestamp: Date;
-  commentCount: string;
+  message: string;
   reviewUrl: string;
 }
 
@@ -62,7 +62,7 @@ export class AppShell extends LitElement {
     };
 
     // Client-only actions that don't need a server round-trip
-    if (detail.name === 'toggle_finding' || detail.name === 'modal_cancel' || detail.name === 'tab_switch' || detail.name === 'slider_change') {
+    if (detail.name === 'toggle_finding' || detail.name === 'modal_cancel' || detail.name === 'tab_switch' || detail.name === 'slider_change' || detail.name === 'text_change' || detail.name === 'choice_change') {
       if (detail.name === 'toggle_finding') {
         this.updateSelectedCount(detail.surfaceId);
       }
@@ -230,7 +230,7 @@ export class AppShell extends LitElement {
 
       // Detect post result: the review surface root changed to "result-col"
       const updatedReview = this.surfaceManager.getSurface('review');
-      if (updatedReview && updatedReview.root === 'result-col' && snapshot) {
+      if (updatedReview && (updatedReview.root === 'result-col' || updatedReview.root === 'issue-result-col') && snapshot) {
         // Extract toast data before restoring
         const message = String(updatedReview.data.result_message ?? 'Review posted');
         const link = String(updatedReview.data.result_link ?? '');
@@ -245,10 +245,9 @@ export class AppShell extends LitElement {
 
         // Record in review history only on successful posts (link is a GitHub URL)
         if (link.includes('github.com')) {
-          const countMatch = message.match(/(\d+)/);
           this.reviewHistory = [...this.reviewHistory, {
             timestamp: new Date(),
-            commentCount: countMatch ? countMatch[1] : '?',
+            message,
             reviewUrl: link,
           }];
         }
@@ -415,7 +414,7 @@ export class AppShell extends LitElement {
         <div class="review-history">
           <button class="review-history__toggle" @click=${() => { this.historyExpanded = !this.historyExpanded; }}>
             <span class="material-icons">${this.historyExpanded ? 'expand_more' : 'chevron_right'}</span>
-            ${this.reviewHistory.length} review${this.reviewHistory.length !== 1 ? 's' : ''} posted
+            ${this.reviewHistory.length} action${this.reviewHistory.length !== 1 ? 's' : ''} taken
           </button>
           ${this.historyExpanded ? html`
             <div class="review-history__list">
@@ -423,7 +422,7 @@ export class AppShell extends LitElement {
                 <div class="review-history__item">
                   <span class="material-icons">check_circle</span>
                   <div class="review-history__meta">
-                    <div class="review-history__count">${entry.commentCount} comments posted</div>
+                    <div class="review-history__count">${entry.message}</div>
                     <div class="review-history__time">${entry.timestamp.toLocaleTimeString()}</div>
                   </div>
                   ${entry.reviewUrl ? html`

--- a/client/src/renderer.ts
+++ b/client/src/renderer.ts
@@ -77,6 +77,12 @@ export function renderComponent(
     case 'Slider':
       content = renderSlider(props, surface, id, scope);
       break;
+    case 'TextField':
+      content = renderTextField(props, surface, id, scope);
+      break;
+    case 'MultipleChoice':
+      content = renderMultipleChoice(props, surface, id, scope);
+      break;
     default:
       content = html`<div class="a2ui-unknown">[Unknown: ${type}]</div>`;
   }
@@ -554,6 +560,137 @@ function renderSlider(
     <div class="a2ui-slider">
       <input type="range" min=${min} max=${max} .value=${String(value)} @input=${handleInput} />
       <span class="a2ui-slider__value">${label}</span>
+    </div>
+  `;
+}
+
+function renderTextField(
+  props: Record<string, unknown>,
+  surface: Surface,
+  componentId: string,
+  scope?: string,
+): TemplateResult {
+  const labelBinding = props.label as BoundValue | undefined;
+  const textBinding = props.text as BoundValue | undefined;
+  const fieldType = (props.textFieldType as string) || 'shortText';
+  const label = labelBinding ? String(resolveValue(labelBinding, surface.data, scope) ?? '') : '';
+  const value = textBinding ? String(resolveValue(textBinding, surface.data, scope) ?? '') : '';
+
+  const handleInput = (e: Event) => {
+    const newValue = (e.target as HTMLInputElement | HTMLTextAreaElement).value;
+
+    if (textBinding && 'path' in textBinding) {
+      const p = textBinding.path;
+      const fullPath = p.startsWith('/') ? p : (scope ? `${scope}/${p}` : p);
+      const segments = fullPath.replace(/^\//, '').split('/').filter(Boolean);
+      let current: Record<string, unknown> = surface.data;
+      for (let i = 0; i < segments.length - 1; i++) {
+        const seg = segments[i];
+        if (current[seg] == null || typeof current[seg] !== 'object') {
+          current[seg] = {};
+        }
+        current = current[seg] as Record<string, unknown>;
+      }
+      current[segments[segments.length - 1]] = newValue;
+    }
+
+    const event = new CustomEvent('a2ui-action', {
+      bubbles: true,
+      composed: true,
+      detail: {
+        name: 'text_change',
+        sourceComponentId: componentId,
+        surfaceId: surface.surfaceId,
+        context: { value: newValue },
+      },
+    });
+    document.dispatchEvent(event);
+  };
+
+  const inputEl = fieldType === 'longText'
+    ? html`<textarea class="a2ui-textfield__input" .value=${value} @input=${handleInput}></textarea>`
+    : html`<input type="text" class="a2ui-textfield__input" .value=${value} @input=${handleInput} />`;
+
+  return html`
+    <div class="a2ui-textfield">
+      ${label ? html`<label class="a2ui-textfield__label">${label}</label>` : nothing}
+      ${inputEl}
+    </div>
+  `;
+}
+
+function renderMultipleChoice(
+  props: Record<string, unknown>,
+  surface: Surface,
+  componentId: string,
+  scope?: string,
+): TemplateResult {
+  const selectionsBinding = props.selections as BoundValue | undefined;
+  const options = props.options as Array<{key: BoundValue; label: BoundValue}> | undefined;
+  const maxSelections = props.maxAllowedSelections as number | undefined;
+
+  const selections = selectionsBinding
+    ? (resolveValue(selectionsBinding, surface.data, scope) as Record<string, unknown> | null) ?? {}
+    : {};
+
+  if (!options || options.length === 0) {
+    return html`<div class="a2ui-multiple-choice"></div>`;
+  }
+
+  const handleToggle = (optionKey: string, checked: boolean) => {
+    if (selectionsBinding && 'path' in selectionsBinding) {
+      const p = selectionsBinding.path;
+      const fullPath = p.startsWith('/') ? p : (scope ? `${scope}/${p}` : p);
+      const segments = fullPath.replace(/^\//, '').split('/').filter(Boolean);
+      let current: Record<string, unknown> = surface.data;
+      for (let i = 0; i < segments.length - 1; i++) {
+        const seg = segments[i];
+        if (current[seg] == null || typeof current[seg] !== 'object') {
+          current[seg] = {};
+        }
+        current = current[seg] as Record<string, unknown>;
+      }
+      const selectionsObj = (current[segments[segments.length - 1]] ?? {}) as Record<string, unknown>;
+
+      if (checked) {
+        if (maxSelections) {
+          const currentCount = Object.keys(selectionsObj).length;
+          if (currentCount >= maxSelections) return;
+        }
+        selectionsObj[optionKey] = true;
+      } else {
+        delete selectionsObj[optionKey];
+      }
+      current[segments[segments.length - 1]] = selectionsObj;
+    }
+
+    const event = new CustomEvent('a2ui-action', {
+      bubbles: true,
+      composed: true,
+      detail: {
+        name: 'choice_change',
+        sourceComponentId: componentId,
+        surfaceId: surface.surfaceId,
+        context: { key: optionKey, selected: checked },
+      },
+    });
+    document.dispatchEvent(event);
+  };
+
+  return html`
+    <div class="a2ui-multiple-choice">
+      ${options.map((opt) => {
+        const optKey = String(resolveValue(opt.key, surface.data, scope) ?? '');
+        const optLabel = String(resolveValue(opt.label, surface.data, scope) ?? '');
+        const isSelected = optKey in (selections as Record<string, unknown>);
+        return html`
+          <label class="a2ui-choice">
+            <input type="checkbox" .checked=${isSelected}
+              @change=${(e: Event) => handleToggle(optKey, (e.target as HTMLInputElement).checked)} />
+            <span>${optLabel}</span>
+          </label>
+        `;
+      })}
     </div>
   `;
 }

--- a/client/src/styles.ts
+++ b/client/src/styles.ts
@@ -426,6 +426,68 @@ export const appStyles = css`
     text-align: center;
   }
 
+  /* TextField */
+  .a2ui-textfield {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .a2ui-textfield__label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: #1a1a2e;
+  }
+
+  .a2ui-textfield__input {
+    padding: 8px 12px;
+    border: 1px solid #d0d0d0;
+    border-radius: 8px;
+    font-size: 0.875rem;
+    font-family: inherit;
+    outline: none;
+    transition: border-color 0.15s;
+  }
+
+  .a2ui-textfield__input:focus {
+    border-color: #1a73e8;
+  }
+
+  textarea.a2ui-textfield__input {
+    min-height: 80px;
+    resize: vertical;
+  }
+
+  /* MultipleChoice */
+  .a2ui-multiple-choice {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .a2ui-choice {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    border: 1px solid #d0d0d0;
+    border-radius: 16px;
+    cursor: pointer;
+    font-size: 0.8rem;
+    user-select: none;
+    transition: background 0.15s, border-color 0.15s;
+  }
+
+  .a2ui-choice:has(input:checked) {
+    background: #e8f0fe;
+    border-color: #1a73e8;
+    color: #1a73e8;
+  }
+
+  .a2ui-choice input {
+    display: none;
+  }
+
   /* Multi-surface layout */
   .surfaces-layout {
     display: grid;

--- a/server/a2ui_examples.py
+++ b/server/a2ui_examples.py
@@ -72,7 +72,7 @@ Key features:
       {"id": "file-findings-list", "component": {"List": {"direction": "vertical", "children": {"template": {"componentId": "finding-card", "dataBinding": "findings"}}}}},
 
       {"id": "finding-card", "component": {"Card": {"child": "finding-col"}}},
-      {"id": "finding-col", "component": {"Column": {"children": {"explicitList": ["finding-header", "finding-diff", "finding-desc"]}}}},
+      {"id": "finding-col", "component": {"Column": {"children": {"explicitList": ["finding-header", "finding-diff", "finding-desc", "finding-actions"]}}}},
       {"id": "finding-header", "component": {"Row": {"children": {"explicitList": ["finding-checkbox", "severity-icon", "finding-location", "github-link-text"]}, "alignment": "center"}}},
       {"id": "finding-checkbox", "component": {"CheckBox": {"label": {"literalString": ""}, "value": {"path": "selected"}}}},
       {"id": "severity-icon", "component": {"Icon": {"name": {"path": "severity_icon"}}}},
@@ -80,6 +80,11 @@ Key features:
       {"id": "github-link-text", "component": {"Text": {"text": {"path": "github_url"}, "usageHint": "caption"}}},
       {"id": "finding-diff", "component": {"Text": {"text": {"path": "diff_snippet"}, "usageHint": "body"}}},
       {"id": "finding-desc", "component": {"Text": {"text": {"path": "description"}, "usageHint": "body"}}},
+      {"id": "finding-actions", "component": {"Row": {"children": {"explicitList": ["create-issue-btn", "address-btn"]}, "distribution": "end"}}},
+      {"id": "create-issue-text", "component": {"Text": {"text": {"literalString": "Create Issue"}}}},
+      {"id": "create-issue-btn", "component": {"Button": {"child": "create-issue-text", "action": {"name": "create_issue", "context": [{"key": "description", "value": {"path": "description"}}, {"key": "filePath", "value": {"path": "file_path"}}, {"key": "prUrl", "value": {"path": "/pr_url_raw"}}]}}}},
+      {"id": "address-text", "component": {"Text": {"text": {"literalString": "Address"}}}},
+      {"id": "address-btn", "component": {"Button": {"child": "address-text", "action": {"name": "address_finding", "context": [{"key": "description", "value": {"path": "description"}}, {"key": "filePath", "value": {"path": "file_path"}}, {"key": "prUrl", "value": {"path": "/pr_url_raw"}}]}}}},
       {"id": "divider-2", "component": {"Divider": {}}},
 
       {"id": "post-modal", "component": {"Modal": {"entryPointChild": "post-selected-btn", "contentChild": "modal-content-col"}}},
@@ -289,4 +294,73 @@ IMPORTANT: Use surfaceId "review" to replace the existing review dashboard in-pl
   {"beginRendering": {"surfaceId": "review", "root": "result-col", "styles": {"primaryColor": "#1a73e8", "font": "Roboto"}}}
 ]
 ---END POST_REVIEW_RESULT_EXAMPLE---
+
+---BEGIN ISSUE_FORM_EXAMPLE---
+Use this template when the user clicks "Create Issue" on a finding.
+Show a form with editable title, body (longText), and label picker (MultipleChoice).
+IMPORTANT: Use surfaceId "review" to replace the dashboard temporarily.
+The labels should come from the fetch_repo_labels tool result.
+If no labels are available, omit the labels-choice component from the form.
+
+[
+  {"surfaceUpdate": {
+    "surfaceId": "review",
+    "components": [
+      {"id": "issue-form-col", "component": {"Column": {"children": {"explicitList": ["form-title", "title-field", "body-field", "labels-heading", "labels-choice", "form-actions"]}, "alignment": "stretch"}}},
+      {"id": "form-title", "component": {"Text": {"text": {"literalString": "Create Issue"}, "usageHint": "h2"}}},
+      {"id": "title-field", "component": {"TextField": {"label": {"literalString": "Title"}, "text": {"path": "/issue_title"}, "textFieldType": "shortText"}}},
+      {"id": "body-field", "component": {"TextField": {"label": {"literalString": "Body"}, "text": {"path": "/issue_body"}, "textFieldType": "longText"}}},
+      {"id": "labels-heading", "component": {"Text": {"text": {"literalString": "Labels"}, "usageHint": "h4"}}},
+      {"id": "labels-choice", "component": {"MultipleChoice": {"selections": {"path": "/issue_labels"}, "options": [{"key": {"literalString": "bug"}, "label": {"literalString": "bug"}}, {"key": {"literalString": "enhancement"}, "label": {"literalString": "enhancement"}}]}}},
+      {"id": "form-actions", "component": {"Row": {"children": {"explicitList": ["form-cancel-btn", "form-submit-btn"]}, "distribution": "end"}}},
+      {"id": "form-cancel-text", "component": {"Text": {"text": {"literalString": "Cancel"}}}},
+      {"id": "form-cancel-btn", "component": {"Button": {"child": "form-cancel-text", "action": {"name": "modal_cancel"}}}},
+      {"id": "form-submit-text", "component": {"Text": {"text": {"literalString": "Create Issue"}}}},
+      {"id": "form-submit-btn", "component": {"Button": {"child": "form-submit-text", "primary": true, "action": {"name": "create_issue_submit", "context": [{"key": "prUrl", "value": {"path": "/pr_url_raw"}}, {"key": "title", "value": {"path": "/issue_title"}}, {"key": "body", "value": {"path": "/issue_body"}}, {"key": "labels", "value": {"path": "/issue_labels"}}]}}}}
+    ]
+  }},
+  {"dataModelUpdate": {
+    "surfaceId": "review",
+    "path": "/",
+    "contents": [
+      {"key": "pr_url_raw", "valueString": "https://github.com/owner/repo/pull/42"},
+      {"key": "issue_title", "valueString": "Fix: Missing null check in src/auth.py:45"},
+      {"key": "issue_body", "valueString": "Found during code review.\\n\\nMissing explicit null check. `if user` evaluates falsy for empty strings and zero.\\n\\nFile: src/auth.py:45-52"},
+      {"key": "issue_labels", "valueMap": []}
+    ]
+  }},
+  {"beginRendering": {"surfaceId": "review", "root": "issue-form-col", "styles": {"primaryColor": "#1a73e8", "font": "Roboto"}}}
+]
+---END ISSUE_FORM_EXAMPLE---
+
+---BEGIN ISSUE_RESULT_EXAMPLE---
+Use this template after successfully creating a GitHub issue via the create_github_issue tool.
+Show the issue URL and number. IMPORTANT: Use surfaceId "review" and root "issue-result-col".
+
+[
+  {"surfaceUpdate": {
+    "surfaceId": "review",
+    "components": [
+      {"id": "issue-result-col", "component": {"Column": {"children": {"explicitList": ["issue-result-card"]}}}},
+      {"id": "issue-result-card", "component": {"Card": {"child": "issue-result-card-col"}}},
+      {"id": "issue-result-card-col", "component": {"Column": {"children": {"explicitList": ["issue-result-icon-row", "issue-result-message", "issue-result-link"]}}}},
+      {"id": "issue-result-icon-row", "component": {"Row": {"children": {"explicitList": ["issue-result-icon", "issue-result-title"]}, "alignment": "center"}}},
+      {"id": "issue-result-icon", "component": {"Icon": {"name": "check"}}},
+      {"id": "issue-result-title", "component": {"Text": {"text": {"path": "/result_title"}, "usageHint": "h2"}}},
+      {"id": "issue-result-message", "component": {"Text": {"text": {"path": "/result_message"}, "usageHint": "body"}}},
+      {"id": "issue-result-link", "component": {"Text": {"text": {"path": "/result_link"}, "usageHint": "caption"}}}
+    ]
+  }},
+  {"dataModelUpdate": {
+    "surfaceId": "review",
+    "path": "/",
+    "contents": [
+      {"key": "result_title", "valueString": "Issue Created"},
+      {"key": "result_message", "valueString": "Created issue #45 on the repository."},
+      {"key": "result_link", "valueString": "https://github.com/owner/repo/issues/45"}
+    ]
+  }},
+  {"beginRendering": {"surfaceId": "review", "root": "issue-result-col", "styles": {"primaryColor": "#1a73e8", "font": "Roboto"}}}
+]
+---END ISSUE_RESULT_EXAMPLE---
 """

--- a/server/agent.py
+++ b/server/agent.py
@@ -21,7 +21,7 @@ from google.adk.sessions import InMemorySessionService
 from google.genai import types
 from a2ui_schema import A2UI_SCHEMA
 from prompt_builder import get_text_prompt, get_ui_prompt
-from tools import fetch_pr_diff, post_github_review
+from tools import fetch_pr_diff, post_github_review, create_github_issue, post_address_comment, fetch_repo_labels
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +50,16 @@ SEVERITY LEVELS:
 - Use icon "error" for critical issues (security, data loss)
 - Use icon "warning" for bugs, logic issues, silent failures
 - Use icon "info" for minor suggestions, style improvements
+
+6. When the user wants to create a GitHub issue from a finding, first call `fetch_repo_labels`
+   to get available labels, then show the ISSUE_FORM_EXAMPLE template with pre-filled title and body,
+   and the labels as MultipleChoice options.
+7. When the user submits the issue form ("create_issue_submit"), call `create_github_issue`
+   with the PR URL, title, body, and selected labels. Then show a confirmation using
+   the ISSUE_RESULT_EXAMPLE template.
+8. When the user wants to mark a finding as "address before merge", call `post_address_comment`
+   with the PR URL, finding description, and file path. Then show a confirmation using
+   the POST_REVIEW_RESULT_EXAMPLE template.
 
 When the user clicks "Will Address" or "Dismiss" on a finding, acknowledge their
 decision and show a brief confirmation.
@@ -100,7 +110,7 @@ class CodeReviewAgent:
             name="code_review_agent",
             description="An agent that reviews GitHub PRs and identifies critical code issues.",
             instruction=instruction,
-            tools=[fetch_pr_diff, post_github_review],
+            tools=[fetch_pr_diff, post_github_review, create_github_issue, post_address_comment, fetch_repo_labels],
         )
 
     async def stream(self, query: str, session_id: str) -> AsyncIterable[dict[str, Any]]:

--- a/server/agent_executor.py
+++ b/server/agent_executor.py
@@ -88,6 +88,40 @@ class CodeReviewAgentExecutor(AgentExecutor):
                     f"event='COMMENT'. "
                     "After posting, show a confirmation using the POST_REVIEW_RESULT_EXAMPLE template."
                 )
+            elif action == "create_issue":
+                finding_desc = ctx.get("description", "")
+                finding_path = ctx.get("filePath", "")
+                pr_url = ctx.get("prUrl", "")
+                query = (
+                    f"The user wants to create a GitHub issue from a finding. "
+                    f"First call `fetch_repo_labels` with pr_url='{pr_url}' to get available labels. "
+                    f"Then show an issue creation form using the ISSUE_FORM_EXAMPLE template. "
+                    f"Pre-fill title with 'Fix: {finding_desc[:60]}', "
+                    f"body with 'Found during code review.\\n\\n{finding_desc}\\n\\nFile: {finding_path}'. "
+                    f"Include the fetched labels as MultipleChoice options. "
+                    f"Set pr_url_raw to '{pr_url}'."
+                )
+            elif action == "create_issue_submit":
+                pr_url = ctx.get("prUrl", "")
+                title = ctx.get("title", "")
+                body = ctx.get("body", "")
+                labels = ctx.get("labels", "[]")
+                query = (
+                    f"The user wants to submit a GitHub issue. "
+                    f"Call the `create_github_issue` tool with pr_url='{pr_url}', "
+                    f"title='{title}', body='{body}', labels_json='{labels}'. "
+                    "After creating, show a confirmation using the ISSUE_RESULT_EXAMPLE template."
+                )
+            elif action == "address_finding":
+                pr_url = ctx.get("prUrl", "")
+                description = ctx.get("description", "")
+                file_path = ctx.get("filePath", "")
+                query = (
+                    f"The user wants to mark a finding as 'must address before merge'. "
+                    f"Call the `post_address_comment` tool with pr_url='{pr_url}', "
+                    f"finding_description='{description}', file_path='{file_path}'. "
+                    "After posting, show a confirmation using the POST_REVIEW_RESULT_EXAMPLE template."
+                )
             else:
                 query = f"User action: {action} with context: {ctx}"
         else:

--- a/server/prompt_builder.py
+++ b/server/prompt_builder.py
@@ -63,6 +63,25 @@ To generate the response, you MUST follow these rules:
 - Place in a Row with a caption label before the summary card.
 - Set /severity_threshold to 0 (valueNumber) in the data model.
 
+--- TEXTFIELD ---
+- TextField component has: label (BoundValue), text (BoundValue for initial value), textFieldType (shortText or longText).
+- Use shortText for titles/single-line input. Use longText for multi-line body text.
+- Bind text to a data model path so the client can read the edited value.
+
+--- MULTIPLE CHOICE ---
+- MultipleChoice component has: selections (BoundValue pointing to selected keys map), options (array of objects with key and label BoundValues).
+- Options use BoundValue for both key and label.
+- selections is a valueMap in the data model where key presence = selected.
+
+--- CREATE ISSUE ---
+- For "create_issue" actions: First call fetch_repo_labels to get available labels, then show ISSUE_FORM_EXAMPLE template with pre-filled title and body and labels as MultipleChoice options.
+- For "create_issue_submit" actions: Call create_github_issue tool, then show ISSUE_RESULT_EXAMPLE template.
+- The "Cancel" button on the issue form dispatches "modal_cancel" which is handled client-side.
+
+--- ADDRESS BEFORE MERGE ---
+- For "address_finding" actions: Call post_address_comment tool, then show POST_REVIEW_RESULT_EXAMPLE template.
+- The result message should say "Address comment posted on PR" and include the comment URL.
+
 --- SIDEBAR SURFACE ---
 - Generate a SECOND surface with surfaceId "sidebar" alongside the main "review" surface.
 - The sidebar shows a file tree: heading "Files", then a List of file items.

--- a/server/tools.py
+++ b/server/tools.py
@@ -300,6 +300,177 @@ def post_github_review(
     })
 
 
+def create_github_issue(
+    pr_url: str,
+    title: str,
+    body: str,
+    labels_json: str,
+    tool_context: ToolContext,
+) -> str:
+    """Create a GitHub issue on the repository associated with a pull request.
+
+    Args:
+        pr_url: Full GitHub PR URL (e.g., https://github.com/owner/repo/pull/123)
+        title: Issue title
+        body: Issue body text
+        labels_json: JSON array string of label names (e.g., '["bug", "security"]')
+
+    Returns:
+        JSON string with success status, issue URL, and issue number, or error details.
+    """
+    logger.info("--- TOOL CALLED: create_github_issue ---")
+    logger.info(f"  - PR URL: {pr_url}, Title: {title[:80]}")
+
+    match = re.match(r"https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)", pr_url)
+    if not match:
+        return json.dumps({"error": f"Invalid GitHub PR URL: {pr_url}"})
+
+    owner, repo, _pr_number = match.groups()
+    token = os.getenv("GITHUB_TOKEN", "")
+
+    if not token:
+        return json.dumps({"error": "GITHUB_TOKEN environment variable is not set."})
+
+    headers: dict[str, str] = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    try:
+        labels = json.loads(labels_json) if labels_json else []
+    except json.JSONDecodeError:
+        labels = []
+
+    payload: dict[str, str | list[str]] = {"title": title, "body": body}
+    if labels:
+        payload["labels"] = labels
+
+    issues_url = f"https://api.github.com/repos/{owner}/{repo}/issues"
+
+    try:
+        resp = requests.post(issues_url, headers=headers, json=payload, timeout=30)
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        error_detail = ""
+        resp_obj = getattr(e, "response", None)
+        if resp_obj is not None:
+            error_detail = f" Response: {resp_obj.text[:500]}"
+        logger.error(f"  - Failed to create issue: {e}{error_detail}")
+        return json.dumps({"error": f"Failed to create issue: {e}{error_detail}"})
+
+    result = resp.json()
+    html_url = result.get("html_url", "")
+    issue_number = result.get("number", 0)
+    logger.info(f"  - Success: Issue #{issue_number} created at {html_url}")
+    return json.dumps({
+        "success": True,
+        "issue_url": html_url,
+        "issue_number": issue_number,
+    })
+
+
+def post_address_comment(
+    pr_url: str,
+    finding_description: str,
+    file_path: str,
+    tool_context: ToolContext,
+) -> str:
+    """Post a 'must address before merge' comment on a GitHub pull request.
+
+    Args:
+        pr_url: Full GitHub PR URL (e.g., https://github.com/owner/repo/pull/123)
+        finding_description: Description of the finding that must be addressed
+        file_path: File path where the finding was identified
+
+    Returns:
+        JSON string with success status and comment URL, or error details.
+    """
+    logger.info("--- TOOL CALLED: post_address_comment ---")
+    logger.info(f"  - PR URL: {pr_url}, File: {file_path}")
+
+    match = re.match(r"https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)", pr_url)
+    if not match:
+        return json.dumps({"error": f"Invalid GitHub PR URL: {pr_url}"})
+
+    owner, repo, pr_number = match.groups()
+    token = os.getenv("GITHUB_TOKEN", "")
+
+    if not token:
+        return json.dumps({"error": "GITHUB_TOKEN environment variable is not set."})
+
+    headers: dict[str, str] = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    comment_body = (
+        f"**Must address before merge:**\n\n"
+        f"{finding_description}\n\n"
+        f"File: {file_path}"
+    )
+
+    comments_url = f"https://api.github.com/repos/{owner}/{repo}/issues/{pr_number}/comments"
+
+    try:
+        resp = requests.post(comments_url, headers=headers, json={"body": comment_body}, timeout=30)
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        error_detail = ""
+        resp_obj = getattr(e, "response", None)
+        if resp_obj is not None:
+            error_detail = f" Response: {resp_obj.text[:500]}"
+        logger.error(f"  - Failed to post comment: {e}{error_detail}")
+        return json.dumps({"error": f"Failed to post comment: {e}{error_detail}"})
+
+    result = resp.json()
+    html_url = result.get("html_url", "")
+    logger.info(f"  - Success: Comment posted at {html_url}")
+    return json.dumps({
+        "success": True,
+        "comment_url": html_url,
+    })
+
+
+def fetch_repo_labels(pr_url: str, tool_context: ToolContext) -> str:
+    """Fetch available labels for the repository associated with a pull request.
+
+    Args:
+        pr_url: Full GitHub PR URL (e.g., https://github.com/owner/repo/pull/123)
+
+    Returns:
+        JSON array string of label objects with name and color fields.
+    """
+    logger.info("--- TOOL CALLED: fetch_repo_labels ---")
+    logger.info(f"  - PR URL: {pr_url}")
+
+    match = re.match(r"https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)", pr_url)
+    if not match:
+        return json.dumps({"error": f"Invalid GitHub PR URL: {pr_url}"})
+
+    owner, repo, _pr_number = match.groups()
+    token = os.getenv("GITHUB_TOKEN", "")
+
+    headers: dict[str, str] = {"X-GitHub-Api-Version": "2022-11-28"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    headers["Accept"] = "application/vnd.github+json"
+
+    labels_url = f"https://api.github.com/repos/{owner}/{repo}/labels"
+
+    try:
+        resp = requests.get(labels_url, headers=headers, timeout=15)
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        logger.error(f"  - Failed to fetch labels: {e}")
+        return json.dumps([])
+
+    labels = [{"name": l["name"], "color": l.get("color", "")} for l in resp.json()]
+    logger.info(f"  - Success: Found {len(labels)} labels")
+    return json.dumps(labels)
+
+
 def _fetch_pr_files_fallback(
     owner: str, repo: str, pr_number: str, headers: dict[str, str], meta: dict,
 ) -> str:


### PR DESCRIPTION
## Summary

- Add per-finding "Create Issue" and "Address Before Merge" action buttons to the review dashboard
- Implement TextField (shortText/longText) and MultipleChoice (chip-style) A2UI component renderers
- Add `create_github_issue`, `post_address_comment`, and `fetch_repo_labels` server tools
- Add issue form and result A2UI templates with full action routing
- Extend review history to track all action types (reviews, issues, address comments)

## Test plan

- [ ] Run `bunx --bun tsc --noEmit` in client — should pass with 0 errors
- [ ] Run `bunx --bun vite build` in client — should build successfully
- [ ] Run server import validation — all tools and agents import cleanly
- [ ] Start server + client, enter a real PR URL
- [ ] Verify "Create Issue" and "Address" buttons appear on each finding card
- [ ] Click "Create Issue" — form appears with editable title, body, and label picker
- [ ] Submit form — issue created on GitHub, toast shown with link
- [ ] Click "Address" on a finding — PR comment posted, toast shown
- [ ] Review history shows all actions taken
- [ ] Click "Cancel" on issue form — dashboard restored