### PR TITLE
Add issue cross-referencing and auto-close suggestions

### DIFF
--- a/client/src/components/app-shell.ts
+++ b/client/src/components/app-shell.ts
@@ -230,7 +230,7 @@ export class AppShell extends LitElement {
 
       // Detect post result: the review surface root changed to "result-col"
       const updatedReview = this.surfaceManager.getSurface('review');
-      if (updatedReview && (updatedReview.root === 'result-col' || updatedReview.root === 'issue-result-col') && snapshot) {
+      if (updatedReview && (updatedReview.root === 'result-col' || updatedReview.root === 'issue-result-col' || updatedReview.root === 'link-result-col') && snapshot) {
         // Extract toast data before restoring
         const message = String(updatedReview.data.result_message ?? 'Review posted');
         const link = String(updatedReview.data.result_link ?? '');

--- a/client/src/renderer.ts
+++ b/client/src/renderer.ts
@@ -94,7 +94,6 @@ export function renderComponent(
 }
 
 function isDiffContent(text: string): boolean {
-  if (!text.includes('\n') && !text.includes('\\n')) return false;
   // Split on actual newlines or escaped newlines
   const lines = text.includes('\n') ? text.split('\n') : text.split('\\n');
   let diffLineCount = 0;
@@ -105,7 +104,7 @@ function isDiffContent(text: string): boolean {
     }
     if (trimmed.length > 200) return false;
   }
-  return diffLineCount >= 2;
+  return diffLineCount >= 1;
 }
 
 function escapeHtml(str: string): string {

--- a/client/src/styles.ts
+++ b/client/src/styles.ts
@@ -158,12 +158,14 @@ export const appStyles = css`
     font-size: 0.95rem;
     margin: 0;
     line-height: 1.5;
+    overflow-wrap: break-word;
   }
 
   .a2ui-text--caption {
     font-size: 0.8rem;
     color: #666;
     margin: 0;
+    overflow-wrap: break-word;
   }
 
   .a2ui-text--link {
@@ -180,12 +182,14 @@ export const appStyles = css`
     display: flex;
     flex-direction: column;
     gap: 12px;
+    min-width: 0;
   }
 
   .a2ui-row {
     display: flex;
     flex-direction: row;
     gap: 12px;
+    min-width: 0;
   }
 
   @keyframes fadeInUp {
@@ -199,6 +203,8 @@ export const appStyles = css`
     background: white;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.06);
     animation: fadeInUp 0.3s ease-out both;
+    min-width: 0;
+    overflow: hidden;
   }
 
   .a2ui-card--critical {
@@ -218,6 +224,7 @@ export const appStyles = css`
     flex-direction: column;
     gap: 8px;
     overflow: auto;
+    min-width: 0;
   }
 
   .a2ui-list--horizontal {
@@ -225,6 +232,7 @@ export const appStyles = css`
     flex-direction: row;
     gap: 8px;
     overflow: auto;
+    min-width: 0;
   }
 
   .a2ui-button {
@@ -500,6 +508,7 @@ export const appStyles = css`
     display: flex;
     flex-direction: column;
     gap: 16px;
+    min-width: 0;
   }
 
   .surface-container {
@@ -507,6 +516,8 @@ export const appStyles = css`
     border-radius: 12px;
     padding: 20px;
     box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.06);
+    min-width: 0;
+    overflow: hidden;
   }
 
   .surface-container--sidebar {

--- a/server/a2ui_examples.py
+++ b/server/a2ui_examples.py
@@ -72,7 +72,7 @@ Key features:
       {"id": "file-findings-list", "component": {"List": {"direction": "vertical", "children": {"template": {"componentId": "finding-card", "dataBinding": "findings"}}}}},
 
       {"id": "finding-card", "component": {"Card": {"child": "finding-col"}}},
-      {"id": "finding-col", "component": {"Column": {"children": {"explicitList": ["finding-header", "finding-diff", "finding-desc", "related-issues-section", "finding-actions"]}}}},
+      {"id": "finding-col", "component": {"Column": {"children": {"explicitList": ["finding-header", "finding-diff", "finding-desc", "related-items", "finding-actions"]}}}},
       {"id": "finding-header", "component": {"Row": {"children": {"explicitList": ["finding-checkbox", "severity-icon", "finding-location", "github-link-text"]}, "alignment": "center"}}},
       {"id": "finding-checkbox", "component": {"CheckBox": {"label": {"literalString": ""}, "value": {"path": "selected"}}}},
       {"id": "severity-icon", "component": {"Icon": {"name": {"path": "severity_icon"}}}},
@@ -80,8 +80,6 @@ Key features:
       {"id": "github-link-text", "component": {"Text": {"text": {"path": "github_url"}, "usageHint": "caption"}}},
       {"id": "finding-diff", "component": {"Text": {"text": {"path": "diff_snippet"}, "usageHint": "body"}}},
       {"id": "finding-desc", "component": {"Text": {"text": {"path": "description"}, "usageHint": "body"}}},
-      {"id": "related-issues-section", "component": {"Column": {"children": {"explicitList": ["related-heading", "related-items"]}}}},
-      {"id": "related-heading", "component": {"Text": {"text": {"literalString": "Possibly related:"}, "usageHint": "caption"}}},
       {"id": "related-items", "component": {"List": {"direction": "vertical", "children": {"template": {"componentId": "related-issue-row", "dataBinding": "related_issues"}}}}},
       {"id": "related-issue-row", "component": {"Row": {"children": {"explicitList": ["related-issue-text", "related-issue-link"]}, "alignment": "center"}}},
       {"id": "related-issue-text", "weight": 1, "component": {"Text": {"text": {"path": "label"}, "usageHint": "caption"}}},

--- a/server/a2ui_examples.py
+++ b/server/a2ui_examples.py
@@ -72,7 +72,7 @@ Key features:
       {"id": "file-findings-list", "component": {"List": {"direction": "vertical", "children": {"template": {"componentId": "finding-card", "dataBinding": "findings"}}}}},
 
       {"id": "finding-card", "component": {"Card": {"child": "finding-col"}}},
-      {"id": "finding-col", "component": {"Column": {"children": {"explicitList": ["finding-header", "finding-diff", "finding-desc", "finding-actions"]}}}},
+      {"id": "finding-col", "component": {"Column": {"children": {"explicitList": ["finding-header", "finding-diff", "finding-desc", "related-issues-section", "finding-actions"]}}}},
       {"id": "finding-header", "component": {"Row": {"children": {"explicitList": ["finding-checkbox", "severity-icon", "finding-location", "github-link-text"]}, "alignment": "center"}}},
       {"id": "finding-checkbox", "component": {"CheckBox": {"label": {"literalString": ""}, "value": {"path": "selected"}}}},
       {"id": "severity-icon", "component": {"Icon": {"name": {"path": "severity_icon"}}}},
@@ -80,6 +80,12 @@ Key features:
       {"id": "github-link-text", "component": {"Text": {"text": {"path": "github_url"}, "usageHint": "caption"}}},
       {"id": "finding-diff", "component": {"Text": {"text": {"path": "diff_snippet"}, "usageHint": "body"}}},
       {"id": "finding-desc", "component": {"Text": {"text": {"path": "description"}, "usageHint": "body"}}},
+      {"id": "related-issues-section", "component": {"Column": {"children": {"explicitList": ["related-heading", "related-items"]}}}},
+      {"id": "related-heading", "component": {"Text": {"text": {"literalString": "Possibly related:"}, "usageHint": "caption"}}},
+      {"id": "related-items", "component": {"List": {"direction": "vertical", "children": {"template": {"componentId": "related-issue-row", "dataBinding": "related_issues"}}}}},
+      {"id": "related-issue-row", "component": {"Row": {"children": {"explicitList": ["related-issue-text", "related-issue-link"]}, "alignment": "center"}}},
+      {"id": "related-issue-text", "weight": 1, "component": {"Text": {"text": {"path": "label"}, "usageHint": "caption"}}},
+      {"id": "related-issue-link", "component": {"Text": {"text": {"path": "url"}, "usageHint": "caption"}}},
       {"id": "finding-actions", "component": {"Row": {"children": {"explicitList": ["create-issue-btn", "address-btn"]}, "distribution": "end"}}},
       {"id": "create-issue-text", "component": {"Text": {"text": {"literalString": "Create Issue"}}}},
       {"id": "create-issue-btn", "component": {"Button": {"child": "create-issue-text", "action": {"name": "create_issue", "context": [{"key": "description", "value": {"path": "description"}}, {"key": "filePath", "value": {"path": "file_path"}}, {"key": "prUrl", "value": {"path": "/pr_url_raw"}}]}}}},
@@ -131,7 +137,13 @@ Key features:
               {"key": "github_url", "valueString": "https://github.com/owner/repo/blob/abc123/src/auth.py#L45-L52"},
               {"key": "diff_snippet", "valueString": "- if user:\\n+ if user is not None:"},
               {"key": "description", "valueString": "Missing explicit null check. `if user` evaluates falsy for empty strings and zero, potentially allowing unauthorized access."},
-              {"key": "selected", "valueBoolean": true}
+              {"key": "selected", "valueBoolean": true},
+              {"key": "related_issues", "valueMap": [
+                {"key": "issue_87", "valueMap": [
+                  {"key": "label", "valueString": "#87 — Null check bypass in auth middleware"},
+                  {"key": "url", "valueString": "https://github.com/owner/repo/issues/87"}
+                ]}
+              ]}
             ]}
           ]}
         ]},
@@ -146,7 +158,8 @@ Key features:
               {"key": "github_url", "valueString": "https://github.com/owner/repo/blob/abc123/src/auth.py#L45-L52"},
               {"key": "diff_snippet", "valueString": "+ query = \\"SELECT * FROM users WHERE id = \\" + str(user_id)"},
               {"key": "description", "valueString": "Potential SQL injection via string concatenation. Use parameterized queries instead."},
-              {"key": "selected", "valueBoolean": true}
+              {"key": "selected", "valueBoolean": true},
+              {"key": "related_issues", "valueMap": []}
             ]}
           ]}
         ]}
@@ -163,7 +176,13 @@ Key features:
               {"key": "github_url", "valueString": "https://github.com/owner/repo/blob/abc123/src/auth.py#L45-L52"},
               {"key": "diff_snippet", "valueString": "- if user:\\n+ if user is not None:"},
               {"key": "description", "valueString": "Missing explicit null check. `if user` evaluates falsy for empty strings and zero, potentially allowing unauthorized access."},
-              {"key": "selected", "valueBoolean": true}
+              {"key": "selected", "valueBoolean": true},
+              {"key": "related_issues", "valueMap": [
+                {"key": "issue_87", "valueMap": [
+                  {"key": "label", "valueString": "#87 — Null check bypass in auth middleware"},
+                  {"key": "url", "valueString": "https://github.com/owner/repo/issues/87"}
+                ]}
+              ]}
             ]}
           ]}
         ]}
@@ -180,7 +199,8 @@ Key features:
               {"key": "github_url", "valueString": "https://github.com/owner/repo/blob/abc123/src/auth.py#L45-L52"},
               {"key": "diff_snippet", "valueString": "+ query = \\"SELECT * FROM users WHERE id = \\" + str(user_id)"},
               {"key": "description", "valueString": "Potential SQL injection via string concatenation. Use parameterized queries instead."},
-              {"key": "selected", "valueBoolean": true}
+              {"key": "selected", "valueBoolean": true},
+              {"key": "related_issues", "valueMap": []}
             ]}
           ]}
         ]}
@@ -363,4 +383,68 @@ Show the issue URL and number. IMPORTANT: Use surfaceId "review" and root "issue
   {"beginRendering": {"surfaceId": "review", "root": "issue-result-col", "styles": {"primaryColor": "#1a73e8", "font": "Roboto"}}}
 ]
 ---END ISSUE_RESULT_EXAMPLE---
+
+---BEGIN SUGGESTED_CLOSURES_EXAMPLE---
+Use this template when the PR appears to fix existing open issues.
+Show this card in the review dashboard between divider-1 and severity-tabs.
+When there ARE suggested closures, add "closures-card" to root-col children between "divider-1" and "severity-tabs".
+When there are NO suggested closures, do NOT include "closures-card" in root-col children.
+
+Components to add to the surfaceUpdate alongside the review dashboard components:
+
+      {"id": "closures-card", "component": {"Card": {"child": "closures-col"}}},
+      {"id": "closures-col", "component": {"Column": {"children": {"explicitList": ["closures-heading", "closures-desc", "closures-list"]}}}},
+      {"id": "closures-heading", "component": {"Text": {"text": {"literalString": "Suggested Closures"}, "usageHint": "h3"}}},
+      {"id": "closures-desc", "component": {"Text": {"text": {"literalString": "This PR appears to fix:"}, "usageHint": "caption"}}},
+      {"id": "closures-list", "component": {"List": {"direction": "vertical", "children": {"template": {"componentId": "closure-item-row", "dataBinding": "/suggested_closures"}}}}},
+      {"id": "closure-item-row", "component": {"Row": {"children": {"explicitList": ["closure-label-text", "closure-link-btn"]}, "alignment": "center"}}},
+      {"id": "closure-label-text", "weight": 1, "component": {"Text": {"text": {"path": "label"}, "usageHint": "body"}}},
+      {"id": "closure-link-text", "component": {"Text": {"text": {"literalString": "Link to PR"}}}},
+      {"id": "closure-link-btn", "component": {"Button": {"child": "closure-link-text", "action": {"name": "link_fixes", "context": [{"key": "prUrl", "value": {"path": "/pr_url_raw"}}, {"key": "issueNumber", "value": {"path": "number"}}, {"key": "issueTitle", "value": {"path": "title"}}]}}}}
+
+Data model to add alongside the review dashboard data (at root level):
+
+      {"key": "suggested_closures", "valueMap": [
+        {"key": "closure_87", "valueMap": [
+          {"key": "number", "valueNumber": 87},
+          {"key": "title", "valueString": "Null check bypass in auth middleware"},
+          {"key": "label", "valueString": "#87 — Null check bypass in auth middleware"},
+          {"key": "url", "valueString": "https://github.com/owner/repo/issues/87"}
+        ]}
+      ]}
+
+When suggested closures exist, root-col children should be:
+["pr-title", "pr-meta", "threshold-row", "summary-card", "divider-1", "closures-card", "severity-tabs", "divider-2", "post-modal"]
+---END SUGGESTED_CLOSURES_EXAMPLE---
+
+---BEGIN LINK_RESULT_EXAMPLE---
+Use this template after successfully linking an issue to the PR via the link_fixes_to_pr tool.
+IMPORTANT: Use surfaceId "review" and root "link-result-col".
+
+[
+  {"surfaceUpdate": {
+    "surfaceId": "review",
+    "components": [
+      {"id": "link-result-col", "component": {"Column": {"children": {"explicitList": ["link-result-card"]}}}},
+      {"id": "link-result-card", "component": {"Card": {"child": "link-result-card-col"}}},
+      {"id": "link-result-card-col", "component": {"Column": {"children": {"explicitList": ["link-result-icon-row", "link-result-message", "link-result-link"]}}}},
+      {"id": "link-result-icon-row", "component": {"Row": {"children": {"explicitList": ["link-result-icon", "link-result-title"]}, "alignment": "center"}}},
+      {"id": "link-result-icon", "component": {"Icon": {"name": "check"}}},
+      {"id": "link-result-title", "component": {"Text": {"text": {"path": "/result_title"}, "usageHint": "h2"}}},
+      {"id": "link-result-message", "component": {"Text": {"text": {"path": "/result_message"}, "usageHint": "body"}}},
+      {"id": "link-result-link", "component": {"Text": {"text": {"path": "/result_link"}, "usageHint": "caption"}}}
+    ]
+  }},
+  {"dataModelUpdate": {
+    "surfaceId": "review",
+    "path": "/",
+    "contents": [
+      {"key": "result_title", "valueString": "Issue Linked"},
+      {"key": "result_message", "valueString": "Added 'Fixes #87' to PR description."},
+      {"key": "result_link", "valueString": "https://github.com/owner/repo/pull/42"}
+    ]
+  }},
+  {"beginRendering": {"surfaceId": "review", "root": "link-result-col", "styles": {"primaryColor": "#1a73e8", "font": "Roboto"}}}
+]
+---END LINK_RESULT_EXAMPLE---
 """

--- a/server/agent.py
+++ b/server/agent.py
@@ -21,7 +21,7 @@ from google.adk.sessions import InMemorySessionService
 from google.genai import types
 from a2ui_schema import A2UI_SCHEMA
 from prompt_builder import get_text_prompt, get_ui_prompt
-from tools import fetch_pr_diff, post_github_review, create_github_issue, post_address_comment, fetch_repo_labels
+from tools import fetch_pr_diff, post_github_review, create_github_issue, post_address_comment, fetch_repo_labels, search_github_issues, link_fixes_to_pr
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +60,14 @@ SEVERITY LEVELS:
 8. When the user wants to mark a finding as "address before merge", call `post_address_comment`
    with the PR URL, finding description, and file path. Then show a confirmation using
    the POST_REVIEW_RESULT_EXAMPLE template.
+9. During your initial PR review, for EACH finding, extract 2-3 keywords from the description
+   and call `search_github_issues` to find related open issues. Include any matches in the
+   finding's `related_issues` data. Use the REVIEW_DASHBOARD_EXAMPLE template which includes
+   a related-issues-list component in each finding card.
+10. After generating all findings, also check if any open issues appear to be FIXED by this PR.
+    If so, include them in the `suggested_closures` data model and show the SUGGESTED_CLOSURES_EXAMPLE card.
+11. When the user clicks "Link to PR" on a suggested closure, call `link_fixes_to_pr` to append
+    "Fixes #N" to the PR description. Show confirmation using the LINK_RESULT_EXAMPLE template.
 
 When the user clicks "Will Address" or "Dismiss" on a finding, acknowledge their
 decision and show a brief confirmation.
@@ -110,7 +118,7 @@ class CodeReviewAgent:
             name="code_review_agent",
             description="An agent that reviews GitHub PRs and identifies critical code issues.",
             instruction=instruction,
-            tools=[fetch_pr_diff, post_github_review, create_github_issue, post_address_comment, fetch_repo_labels],
+            tools=[fetch_pr_diff, post_github_review, create_github_issue, post_address_comment, fetch_repo_labels, search_github_issues, link_fixes_to_pr],
         )
 
     async def stream(self, query: str, session_id: str) -> AsyncIterable[dict[str, Any]]:

--- a/server/agent_executor.py
+++ b/server/agent_executor.py
@@ -122,6 +122,15 @@ class CodeReviewAgentExecutor(AgentExecutor):
                     f"finding_description='{description}', file_path='{file_path}'. "
                     "After posting, show a confirmation using the POST_REVIEW_RESULT_EXAMPLE template."
                 )
+            elif action == "link_fixes":
+                pr_url = ctx.get("prUrl", "")
+                issue_number = ctx.get("issueNumber", 0)
+                issue_title = ctx.get("issueTitle", "")
+                query = (
+                    f"The user wants to link issue #{issue_number} ('{issue_title}') as fixed by this PR. "
+                    f"Call the `link_fixes_to_pr` tool with pr_url='{pr_url}', issue_number={issue_number}. "
+                    "After linking, show a confirmation using the LINK_RESULT_EXAMPLE template."
+                )
             else:
                 query = f"User action: {action} with context: {ctx}"
         else:

--- a/server/prompt_builder.py
+++ b/server/prompt_builder.py
@@ -82,6 +82,24 @@ To generate the response, you MUST follow these rules:
 - For "address_finding" actions: Call post_address_comment tool, then show POST_REVIEW_RESULT_EXAMPLE template.
 - The result message should say "Address comment posted on PR" and include the comment URL.
 
+--- ISSUE CROSS-REFERENCE ---
+- During initial review, for EACH finding extract 2-3 keywords from the description.
+- Call `search_github_issues` with those keywords for each finding.
+- Include matches in the finding's data model as `related_issues` valueMap.
+- Each related issue has: label (valueString formatted as "#N — title"), url (valueString with the issue URL).
+- If no matches found, set related_issues to an empty valueMap [].
+- The finding card template includes a related-issues-list that renders from this data.
+
+--- SUGGESTED CLOSURES ---
+- After generating all findings, check if any open issues match what the PR is fixing.
+- Look for issues whose titles/descriptions match the PR's changed files or fix descriptions.
+- Include matches in the root data model as `suggested_closures` valueMap.
+- Each closure has: number (valueNumber), title (valueString), label (valueString formatted as "#N — title"), url (valueString).
+- If there are suggested closures, add "closures-card" to root-col children between divider-1 and severity-tabs.
+- If there are NO suggested closures, do NOT include closures-card in the root-col children.
+- Use the SUGGESTED_CLOSURES_EXAMPLE template components.
+- For "link_fixes" actions: Call link_fixes_to_pr tool, then show LINK_RESULT_EXAMPLE template.
+
 --- SIDEBAR SURFACE ---
 - Generate a SECOND surface with surfaceId "sidebar" alongside the main "review" surface.
 - The sidebar shows a file tree: heading "Files", then a List of file items.

--- a/server/prompt_builder.py
+++ b/server/prompt_builder.py
@@ -87,8 +87,8 @@ To generate the response, you MUST follow these rules:
 - Call `search_github_issues` with those keywords for each finding.
 - Include matches in the finding's data model as `related_issues` valueMap.
 - Each related issue has: label (valueString formatted as "#N — title"), url (valueString with the issue URL).
-- If no matches found, set related_issues to an empty valueMap [].
-- The finding card template includes a related-issues-list that renders from this data.
+- If no matches found, set related_issues to an empty valueMap []. The empty list renders nothing in the UI.
+- The finding card template includes a related-items List that renders from this data. No heading is needed — the "#N — title" format is self-explanatory.
 
 --- SUGGESTED CLOSURES ---
 - After generating all findings, check if any open issues match what the PR is fixing.

--- a/server/tools.py
+++ b/server/tools.py
@@ -471,6 +471,140 @@ def fetch_repo_labels(pr_url: str, tool_context: ToolContext) -> str:
     return json.dumps(labels)
 
 
+def search_github_issues(pr_url: str, keywords: str, tool_context: ToolContext) -> str:
+    """Search for open GitHub issues in the repository matching keywords.
+
+    Args:
+        pr_url: Full GitHub PR URL (e.g., https://github.com/owner/repo/pull/123)
+        keywords: Space-separated keywords to search for in issue titles/bodies
+
+    Returns:
+        JSON array string of matching issues with number, title, and url fields.
+    """
+    logger.info("--- TOOL CALLED: search_github_issues ---")
+    logger.info(f"  - PR URL: {pr_url}, Keywords: {keywords}")
+
+    match = re.match(r"https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)", pr_url)
+    if not match:
+        return json.dumps([])
+
+    owner, repo, _pr_number = match.groups()
+    token = os.getenv("GITHUB_TOKEN", "")
+
+    headers: dict[str, str] = {"X-GitHub-Api-Version": "2022-11-28"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    headers["Accept"] = "application/vnd.github+json"
+
+    query = f"repo:{owner}/{repo} type:issue state:open {keywords}"
+    search_url = "https://api.github.com/search/issues"
+
+    try:
+        resp = requests.get(
+            search_url,
+            headers=headers,
+            params={"q": query, "per_page": 5},
+            timeout=15,
+        )
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        logger.error(f"  - Failed to search issues: {e}")
+        return json.dumps([])
+
+    items = resp.json().get("items", [])
+    results = [
+        {
+            "number": item["number"],
+            "title": item["title"],
+            "url": item["html_url"],
+        }
+        for item in items
+    ]
+    logger.info(f"  - Success: Found {len(results)} matching issues")
+    return json.dumps(results)
+
+
+def link_fixes_to_pr(pr_url: str, issue_number: int, tool_context: ToolContext) -> str:
+    """Append 'Fixes #N' to a GitHub PR description to auto-close an issue on merge.
+
+    Args:
+        pr_url: Full GitHub PR URL (e.g., https://github.com/owner/repo/pull/123)
+        issue_number: The issue number to link as fixed
+
+    Returns:
+        JSON string with success status, or error details.
+    """
+    logger.info("--- TOOL CALLED: link_fixes_to_pr ---")
+    logger.info(f"  - PR URL: {pr_url}, Issue: #{issue_number}")
+
+    match = re.match(r"https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)", pr_url)
+    if not match:
+        return json.dumps({"error": f"Invalid GitHub PR URL: {pr_url}"})
+
+    owner, repo, pr_number = match.groups()
+    token = os.getenv("GITHUB_TOKEN", "")
+
+    if not token:
+        return json.dumps({"error": "GITHUB_TOKEN environment variable is not set."})
+
+    headers: dict[str, str] = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    pr_api_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}"
+
+    # Read current PR body
+    try:
+        resp = requests.get(pr_api_url, headers=headers, timeout=15)
+        resp.raise_for_status()
+        pr_data = resp.json()
+    except requests.RequestException as e:
+        logger.error(f"  - Failed to fetch PR: {e}")
+        return json.dumps({"error": f"Failed to fetch PR: {e}"})
+
+    current_body = pr_data.get("body") or ""
+    fixes_ref = f"Fixes #{issue_number}"
+
+    if fixes_ref in current_body:
+        logger.info(f"  - '{fixes_ref}' already in PR description")
+        return json.dumps({
+            "success": True,
+            "already_linked": True,
+            "issue_number": issue_number,
+            "pr_url": pr_data.get("html_url", pr_url),
+        })
+
+    updated_body = current_body + f"\n\n{fixes_ref}"
+
+    try:
+        resp = requests.patch(
+            pr_api_url,
+            headers=headers,
+            json={"body": updated_body},
+            timeout=15,
+        )
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        error_detail = ""
+        resp_obj = getattr(e, "response", None)
+        if resp_obj is not None:
+            error_detail = f" Response: {resp_obj.text[:500]}"
+        logger.error(f"  - Failed to update PR: {e}{error_detail}")
+        return json.dumps({"error": f"Failed to update PR: {e}{error_detail}"})
+
+    result = resp.json()
+    html_url = result.get("html_url", pr_url)
+    logger.info(f"  - Success: Added '{fixes_ref}' to PR description")
+    return json.dumps({
+        "success": True,
+        "already_linked": False,
+        "issue_number": issue_number,
+        "pr_url": html_url,
+    })
+
+
 def _fetch_pr_files_fallback(
     owner: str, repo: str, pr_number: str, headers: dict[str, str], meta: dict,
 ) -> str:


### PR DESCRIPTION
## Summary

- Add `search_github_issues` tool that searches open issues matching keywords from each finding during initial PR analysis
- Add `link_fixes_to_pr` tool that appends "Fixes #N" to PR descriptions via the GitHub API
- Extend finding cards with a "Possibly related" section showing matching open issue links
- Add conditional "Suggested Closures" card between summary and severity tabs when the PR appears to fix known issues
- Each suggested closure has a "Link to PR" button that triggers the link_fixes action
- Result detection in the client handles the new `link-result-col` root for toast/history tracking

## Test plan

- [ ] Review a PR on a repo with open issues — verify findings show "Possibly related" links
- [ ] Review a PR on a repo with no matching issues — verify no related issues section renders
- [ ] Review a PR that fixes a known issue — verify "Suggested Closures" card appears
- [ ] Click "Link to PR" on a suggested closure — verify "Fixes #N" appended to PR description
- [ ] Click "Link to PR" when already linked — verify "already linked" message
- [ ] Verify review history tracks link actions